### PR TITLE
feat: Footer 컴포넌트 구현 (Section, Socials, Bottom bar)

### DIFF
--- a/src/widgets/footer/config/footerLinks.tsx
+++ b/src/widgets/footer/config/footerLinks.tsx
@@ -1,0 +1,36 @@
+import type { FooterSection, SocialLink } from '../model/footerType';
+
+export const SECTIONS: FooterSection[] = [
+  {
+    title: 'Product',
+    links: [
+      { label: '소개', href: '/about' },
+      { label: '변경내역', href: '/changelog' },
+      { label: '문서 / 가이드', href: '/docs' },
+    ],
+  },
+  {
+    title: 'Resources',
+    links: [
+      { label: '자주 묻는 질문', href: '/faq' },
+      { label: '지원', href: '/support' },
+      { label: '개인정보 처리방침', href: '/privacy' },
+      { label: '이용약관', href: '/terms' },
+    ],
+  },
+];
+
+export const SOCIALS: SocialLink[] = [
+  {
+    href: 'https://github.com/kakao-tech-campus-3rd-step3/Team15_FE',
+    label: 'GitHub',
+    icon: <span className='text-lg'>🐙</span>,
+  },
+  { href: '#', label: 'Contact', icon: <span className='text-lg'>✉️</span> },
+];
+
+export const BOTTOMBAR_LINKS = [
+  { label: '보안', href: '/security' },
+  { label: '서비스 상태', href: '/status' },
+  { label: '연락처', href: '/contact' },
+];

--- a/src/widgets/footer/model/footerType.ts
+++ b/src/widgets/footer/model/footerType.ts
@@ -1,0 +1,3 @@
+export type FooterLink = { label: string; href: string };
+export type FooterSection = { title: string; links: FooterLink[] };
+export type SocialLink = { href: string; label: string; icon: React.ReactNode };

--- a/src/widgets/footer/ui/Footer.tsx
+++ b/src/widgets/footer/ui/Footer.tsx
@@ -1,5 +1,53 @@
-import React from 'react';
+import { Separator } from '@/shared/ui/shadcn/separator';
+import { BOTTOMBAR_LINKS, SECTIONS } from '../config/footerLinks';
+import { Section } from './Section';
+import { Socials } from './Socials';
 
 export function Footer() {
-  return <div>Footer</div>;
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className='bg-background w-full border-t'>
+      {/* Top section */}
+      <div className='mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8'>
+        <div className='grid grid-cols-1 gap-10 md:grid-cols-4'>
+          {/* Brand */}
+          <div className='flex flex-col gap-3'>
+            <div className='text-xl font-semibold tracking-tight'>휴 쉼</div>
+            <p className='text-muted-foreground text-sm'>
+              제품 개선 제안과 피드백을 언제든 환영합니다.
+            </p>
+            <Socials />
+          </div>
+
+          {/* Dynamic sections */}
+          {SECTIONS.map((section) => (
+            <Section key={section.title} {...section} />
+          ))}
+        </div>
+      </div>
+
+      {/* Separator */}
+      <Separator />
+
+      {/* Bottom bar */}
+      <div className='mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8'>
+        <div className='flex flex-col items-start justify-between gap-4 md:flex-row md:items-center'>
+          <p className='text-muted-foreground text-xs'>© {year} Team15. All rights reserved.</p>
+
+          <div className='flex items-center gap-4 text-xs'>
+            {BOTTOMBAR_LINKS.map((l) => (
+              <a
+                key={l.href}
+                href={l.href}
+                className='text-muted-foreground hover:text-foreground transition'
+              >
+                {l.label}
+              </a>
+            ))}
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
 }

--- a/src/widgets/footer/ui/Section.tsx
+++ b/src/widgets/footer/ui/Section.tsx
@@ -1,0 +1,18 @@
+import type { FooterSection } from '../model/footerType';
+
+export function Section({ title, links }: FooterSection) {
+  return (
+    <div className='flex flex-col gap-3'>
+      <h3 className='text-foreground text-sm font-medium'>{title}</h3>
+      <ul className='space-y-2 text-sm'>
+        {links.map((l) => (
+          <li key={l.href}>
+            <a href={l.href} className='text-muted-foreground hover:text-foreground transition'>
+              {l.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/widgets/footer/ui/Socials.tsx
+++ b/src/widgets/footer/ui/Socials.tsx
@@ -1,0 +1,20 @@
+import { SOCIALS } from '../config/footerLinks';
+
+export function Socials() {
+  return (
+    <div className='mt-2 flex items-center gap-3'>
+      {SOCIALS.map((s) => (
+        <a
+          key={s.label}
+          href={s.href}
+          target={s.href.startsWith('http') ? '_blank' : undefined}
+          rel={s.href.startsWith('http') ? 'noreferrer' : undefined}
+          aria-label={s.label}
+          className='text-muted-foreground hover:text-foreground transition'
+        >
+          {s.icon}
+        </a>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #32 

## #️⃣ 작업 내용

- `AppLayout`에 **Footer 컴포넌트**를 추가하여 레이아웃 하단 구조를 완성했습니다.  
- Footer 내 nav 링크 데이터(`SECTIONS`, `SOCIALS`)를 **`widget/footer/model` 및 `config` 세그먼트**로 분리하여 유지보수성을 강화했습니다.  
- 반복되는 마크업을 줄이고 **데이터 기반 렌더링**이 가능하도록 리팩터링했습니다.  

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?  
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)  
- [x] 코드 컨벤션에 따라 코드를 작성했나요?  
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?  

## #️⃣ 스크린샷 (선택)

<img width="1360" height="1014" alt="image" src="https://github.com/user-attachments/assets/2eb2b0e2-50ad-4fd7-95a8-3d86b3c2ce96" />

## #️⃣ 리뷰 요구사항 (선택)

- Footer의 nav 링크는 현재 하단 Footer 외에 재사용될 가능성이 적다고 판단하여, `shared`가 아닌 **`widget/footer/model` 및 `config`** 세그먼트에 배치했습니다.  
- Model과 Config의 폴더 구조를 제 기준으로 나누어 사용했는데, 이 방식이 **FSD 관점에서 적절한지** 팀 차원에서 논의해보면 좋겠습니다.  