### PR TITLE
Feature/header sidebar auth

### DIFF
--- a/src/app/layout/AppLayout.tsx
+++ b/src/app/layout/AppLayout.tsx
@@ -1,5 +1,4 @@
 import { Outlet } from 'react-router-dom';
-import { useEffect, useState } from 'react';
 import { Footer } from '@/widgets/footer';
 import { Separator } from '@/shared/ui/shadcn/separator';
 import { SidebarProvider } from '@/shared/ui/shadcn/sidebar';

--- a/src/app/layout/AppLayout.tsx
+++ b/src/app/layout/AppLayout.tsx
@@ -5,26 +5,14 @@ import { Separator } from '@/shared/ui/shadcn/separator';
 import { SidebarProvider } from '@/shared/ui/shadcn/sidebar';
 import { HeaderGuest, HeaderLogin } from '@/widgets/header';
 import { SidebarIndex } from '@/widgets/Sidebar/ui/SidebarIndex';
+import { useAuthStore } from '@/features/auth/model/useAuthStore';
 
 export default function AppLayout() {
-  const read = () =>
-    typeof localStorage !== 'undefined' && localStorage.getItem('app:isLoggedIn') === 'true';
-  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(read());
-
-  useEffect(() => {
-    const handle = () => setIsLoggedIn(read());
-    window.addEventListener('auth:change', handle);
-    window.addEventListener('storage', handle);
-    return () => {
-      window.removeEventListener('auth:change', handle);
-      window.removeEventListener('storage', handle);
-    };
-  }, []);
-  // 로그인 구현 전 임시
+  const { isLoggedIn } = useAuthStore();
 
   return (
     <>
-      {isLoggedIn ? (
+      {!isLoggedIn ? (
         <>
           <HeaderGuest />
           <Separator />

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -15,10 +15,11 @@ function Router() {
         <Route element={<AppLayout />}>
           <Route path={ROUTES.landing} element={<LandingPage />} />
           <Route path={ROUTES.post} element={<HeartNewsPage />} />
-          <Route path={ROUTES.login} element={<AuthPage />} />
+
           <Route path={ROUTES.createpost} element={<Post />} />
           <Route path={ROUTES.my} element={<MyPage />} />
         </Route>
+        <Route path={ROUTES.login} element={<AuthPage />} />
       </Routes>
       <DevPanel />
     </BrowserRouter>

--- a/src/features/auth/api/useLogout.ts
+++ b/src/features/auth/api/useLogout.ts
@@ -1,4 +1,3 @@
-import { useMutation } from '@tanstack/react-query';
 import { useAuthStore } from '../model/useAuthStore';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@/shared/config';
@@ -7,13 +6,10 @@ export const useLogout = () => {
   const logoutStore = useAuthStore((state) => state.logout);
   const navigate = useNavigate();
 
-  return useMutation({
-    mutationFn: async () => {
-      await logoutStore();
-    },
-    onSuccess: () => {
-      alert('로그아웃 성공, 메인페이지로 이동합니다.');
-      navigate(ROUTES.landing);
-    },
-  });
+  const logout = () => {
+    logoutStore();
+    alert('로그아웃 성공, 메인페이지로 이동합니다.');
+    navigate(ROUTES.landing);
+  };
+  return { logout };
 };

--- a/src/features/auth/api/useLogout.ts
+++ b/src/features/auth/api/useLogout.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { useAuthStore } from '../model/useAuthStore';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '@/shared/config';
+
+export const useLogout = () => {
+  const logoutStore = useAuthStore((state) => state.logout);
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: async () => {
+      await logoutStore();
+    },
+    onSuccess: () => {
+      alert('로그아웃 성공, 메인페이지로 이동합니다.');
+      navigate(ROUTES.landing);
+    },
+  });
+};

--- a/src/features/landing-page-filter-post/model/useFilter.ts
+++ b/src/features/landing-page-filter-post/model/useFilter.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { Category } from '@/features/search-posts/api/getCategories';
 
-export function useFilter(initial: Category['code'] = 'ALL') {
+export function useFilter(initial: Category['code'] = 'FREE') {
   const [category, setCategory] = useState<Category['code']>(initial);
   return { category, setCategory } as const;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,17 +17,17 @@
 
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-// import { config } from '@/shared/config/appConfig';
+import { config } from '@/shared/config/appConfig';
 import './main.css';
 
 async function bootstrap() {
-  // if (config.useMock && import.meta.env.DEV) {
-  //   const { worker } = await import('@/shared/api/mocks/browser');
-  //   await worker.start({
-  //     onUnhandledRequest: 'warn',
-  //     serviceWorker: { url: '/mockServiceWorker.js' },
-  //   });
-  // }
+  if (config.useMock && import.meta.env.DEV) {
+    const { worker } = await import('@/shared/api/mocks/browser');
+    await worker.start({
+      onUnhandledRequest: 'warn',
+      serviceWorker: { url: '/mockServiceWorker.js' },
+    });
+  }
 
   const { default: App } = await import('@app/App.tsx');
   createRoot(document.getElementById('root')!).render(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,7 +17,7 @@
 
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { config } from '@/shared/config/appConfig';
+// import { config } from '@/shared/config/appConfig';
 import './main.css';
 
 async function bootstrap() {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,13 +21,13 @@ import { config } from '@/shared/config/appConfig';
 import './main.css';
 
 async function bootstrap() {
-  if (config.useMock && import.meta.env.DEV) {
-    const { worker } = await import('@/shared/api/mocks/browser');
-    await worker.start({
-      onUnhandledRequest: 'warn',
-      serviceWorker: { url: '/mockServiceWorker.js' },
-    });
-  }
+  // if (config.useMock && import.meta.env.DEV) {
+  //   const { worker } = await import('@/shared/api/mocks/browser');
+  //   await worker.start({
+  //     onUnhandledRequest: 'warn',
+  //     serviceWorker: { url: '/mockServiceWorker.js' },
+  //   });
+  // }
 
   const { default: App } = await import('@app/App.tsx');
   createRoot(document.getElementById('root')!).render(

--- a/src/shared/config/routes.ts
+++ b/src/shared/config/routes.ts
@@ -2,7 +2,6 @@ import { NotebookText, Home, MessageCircle, FileText } from 'lucide-react';
 
 export const ROUTES = {
   landing: '/',
-  home: '/home',
   post: '/post',
   createpost: '/post/create',
   login: '/login',
@@ -14,7 +13,6 @@ export const ROUTES = {
 
 export const ROUTE_LIST: { label: string; path: string }[] = [
   { label: '랜딩', path: ROUTES.landing },
-  { label: '홈', path: ROUTES.home },
   { label: '포스터', path: ROUTES.post },
   { label: '포스터 작성', path: ROUTES.createpost },
   { label: '로그인', path: ROUTES.login },
@@ -28,7 +26,7 @@ export const ROUTE_LIST: { label: string; path: string }[] = [
 export const items = [
   {
     title: '홈',
-    url: '/',
+    url: ROUTES.landing,
     icon: Home,
   },
   {
@@ -38,7 +36,7 @@ export const items = [
   },
   {
     title: '마음소식',
-    url: '/news',
+    url: ROUTES.post,
     icon: MessageCircle,
   },
   {

--- a/src/shared/ui/dev-panner/LoginPanel.tsx
+++ b/src/shared/ui/dev-panner/LoginPanel.tsx
@@ -1,40 +1,21 @@
-import { useEffect, useState } from 'react';
+import { useAuthStore } from '@/features/auth/model/useAuthStore';
 
 function LoginPanel() {
-  const read = () =>
-    typeof localStorage !== 'undefined' && localStorage.getItem('app:isLoggedIn') === 'true';
-  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(read());
-
-  // Listen to auth change events (from DevPanel buttons or other tabs)
-  useEffect(() => {
-    const handle = () => setIsLoggedIn(read());
-    window.addEventListener('auth:change', handle);
-    window.addEventListener('storage', handle);
-    return () => {
-      window.removeEventListener('auth:change', handle);
-      window.removeEventListener('storage', handle);
-    };
-  }, []);
-
-  const setAuth = (next: boolean) => {
-    localStorage.setItem('app:isLoggedIn', String(next));
-    window.dispatchEvent(new Event('auth:change'));
-    setIsLoggedIn(next);
-  };
+  const { isLoggedIn, login, logout } = useAuthStore();
 
   return (
     <div className='flex flex-col gap-2'>
       <span className='font-medium'>상태: {isLoggedIn ? '로그인됨' : '로그아웃됨'}</span>
       {!isLoggedIn ? (
         <button
-          onClick={() => setAuth(true)}
+          onClick={() => login('mock-token')}
           className='rounded bg-green-500 px-3 py-1 text-white hover:bg-green-600'
         >
           로그인(모의)
         </button>
       ) : (
         <button
-          onClick={() => setAuth(false)}
+          onClick={() => logout()}
           className='rounded bg-red-500 px-3 py-1 text-white hover:bg-red-600'
         >
           로그아웃(모의)

--- a/src/widgets/HeroSection/ui/HeroSection.tsx
+++ b/src/widgets/HeroSection/ui/HeroSection.tsx
@@ -1,24 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useAuthStore } from '@/features/auth/model/useAuthStore';
 
 export function HeroSection() {
-  const read = () =>
-    typeof localStorage !== 'undefined' && localStorage.getItem('app:isLoggedIn') === 'true';
-  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(read());
-
-  useEffect(() => {
-    const handle = () => setIsLoggedIn(read());
-    window.addEventListener('auth:change', handle);
-    window.addEventListener('storage', handle);
-    return () => {
-      window.removeEventListener('auth:change', handle);
-      window.removeEventListener('storage', handle);
-    };
-  }, []);
-  // 로그인 구현 전 임시
-
+  const { isLoggedIn } = useAuthStore();
   return (
     <section className='py-10 text-center'>
-      {!isLoggedIn && <h1 className='text-primary text-4xl font-extrabold tracking-tight'>휴쉼</h1>}
+      {isLoggedIn && <h1 className='text-primary text-4xl font-extrabold tracking-tight'>휴쉼</h1>}
       <p className='mt-2 text-4xl font-bold'>지금, 1,621개의 마음이 오가는 중이에요.</p>
       <p className='text-muted-foreground mt-4'>
         사소한 생각부터 소중한 기분까지, 어떤 마음이든 여기 남겨도 괜찮아요.

--- a/src/widgets/Sidebar/ui/SidebarContentSection.tsx
+++ b/src/widgets/Sidebar/ui/SidebarContentSection.tsx
@@ -7,6 +7,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@/shared/ui/shadcn/sidebar';
+import { Link } from 'react-router-dom';
 
 function SidebarContentSection() {
   return (
@@ -17,10 +18,10 @@ function SidebarContentSection() {
             {items.map((item) => (
               <SidebarMenuItem key={item.title}>
                 <SidebarMenuButton asChild>
-                  <a href={item.url} className='flex items-center gap-2'>
+                  <Link to={item.url} className='flex items-center gap-2'>
                     <item.icon />
                     <span>{item.title}</span>
-                  </a>
+                  </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
             ))}

--- a/src/widgets/Sidebar/ui/SidebarIndex.tsx
+++ b/src/widgets/Sidebar/ui/SidebarIndex.tsx
@@ -1,6 +1,6 @@
 import { Sidebar, SidebarHeader } from '@/shared/ui/shadcn/sidebar';
 import SidebarContentSection from './SidebarContentSection';
-import SidebarFooterSection from './SidebarFooterSection';
+// import SidebarFooterSection from './SidebarFooterSection';
 
 export function SidebarIndex() {
   return (
@@ -9,7 +9,7 @@ export function SidebarIndex() {
         <span className='block w-full text-center text-xl font-bold'>휴 쉼</span>
       </SidebarHeader>
       <SidebarContentSection />
-      <SidebarFooterSection />
+      {/* <SidebarFooterSection /> */}
     </Sidebar>
   );
 }

--- a/src/widgets/header/ui/HeaderGuest.tsx
+++ b/src/widgets/header/ui/HeaderGuest.tsx
@@ -2,6 +2,7 @@ import { Search } from 'lucide-react';
 import { YSButton } from '@/shared/ui/';
 import { useNavigate } from 'react-router-dom';
 import { navItems } from '../config/const';
+import { ROUTES } from '@/shared/config';
 
 export function HeaderGuest() {
   const navigate = useNavigate();
@@ -38,10 +39,10 @@ export function HeaderGuest() {
           </YSButton>
 
           {/* 로그인 버튼 (연한 테두리 pill) */}
-          <YSButton variant='outline' size='sm'>
+          <YSButton variant='outline' size='sm' onClick={() => navigate(ROUTES.login)}>
             로그인
           </YSButton>
-          <YSButton variant='outline' size='sm'>
+          <YSButton variant='outline' size='sm' onClick={() => navigate(ROUTES.login)}>
             회원가입
           </YSButton>
         </div>

--- a/src/widgets/header/ui/HeaderLogin.tsx
+++ b/src/widgets/header/ui/HeaderLogin.tsx
@@ -17,7 +17,7 @@ export function HeaderLogin() {
   const location = useLocation();
   const pathname = location.pathname;
   const activeItem = getActiveItem(pathname);
-  const { mutate: logout, isPending } = useLogout();
+  const { logout } = useLogout();
   const navigate = useNavigate();
 
   return (
@@ -51,14 +51,8 @@ export function HeaderLogin() {
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-        <Button
-          variant='destructive'
-          size='sm'
-          className='rounded-full'
-          onClick={() => logout()}
-          disabled={isPending}
-        >
-          {isPending ? '로그아웃 중…' : '로그아웃'}
+        <Button variant='destructive' size='sm' className='rounded-full' onClick={() => logout()}>
+          {'로그아웃'}
         </Button>
       </div>
     </div>

--- a/src/widgets/header/ui/HeaderLogin.tsx
+++ b/src/widgets/header/ui/HeaderLogin.tsx
@@ -4,11 +4,13 @@ import { useLocation } from 'react-router-dom';
 import { getActiveItem } from '../model/getActiveItem';
 import { Bell } from 'lucide-react';
 import { Button } from '@/shared/ui/shadcn/button';
+import { useLogout } from '@/features/auth/api/useLogout';
 
 export function HeaderLogin() {
   const location = useLocation();
   const pathname = location.pathname;
   const activeItem = getActiveItem(pathname);
+  const { mutate: logout, isPending } = useLogout();
 
   return (
     <div className='bg-background sticky top-0 z-30 flex h-8 w-full items-center gap-5'>
@@ -24,8 +26,14 @@ export function HeaderLogin() {
           <span className='text-sm font-semibold'>전남대학교</span>
           <span className='text-xs text-gray-500'>전남대1팀</span>
         </div>
-        <Button variant='destructive' size='sm' className='rounded-full'>
-          로그아웃
+        <Button
+          variant='destructive'
+          size='sm'
+          className='rounded-full'
+          onClick={() => logout()}
+          disabled={isPending}
+        >
+          {isPending ? '로그아웃 중…' : '로그아웃'}
         </Button>
       </div>
     </div>

--- a/src/widgets/header/ui/HeaderLogin.tsx
+++ b/src/widgets/header/ui/HeaderLogin.tsx
@@ -1,16 +1,24 @@
 import { Separator } from '@/shared/ui/shadcn/separator';
 import { SidebarTrigger } from '@/shared/ui/shadcn/sidebar';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { getActiveItem } from '../model/getActiveItem';
-import { Bell } from 'lucide-react';
+import { Bell, ChevronDown } from 'lucide-react';
 import { Button } from '@/shared/ui/shadcn/button';
 import { useLogout } from '@/features/auth/api/useLogout';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/shared/ui/shadcn/dropdown-menu';
+import { ROUTES } from '@/shared/config';
 
 export function HeaderLogin() {
   const location = useLocation();
   const pathname = location.pathname;
   const activeItem = getActiveItem(pathname);
   const { mutate: logout, isPending } = useLogout();
+  const navigate = useNavigate();
 
   return (
     <div className='bg-background sticky top-0 z-30 flex h-8 w-full items-center gap-5'>
@@ -18,14 +26,31 @@ export function HeaderLogin() {
       <Separator orientation='vertical' />
       <div className='text-sm font-medium'>{activeItem?.title}</div>
       <div className='ml-auto flex items-center gap-4'>
-        <div className='relative'>
-          <Bell />
-          <span className='absolute right-0 top-0 block h-2 w-2 rounded-full bg-red-500' />
-        </div>
-        <div className='flex flex-col text-right'>
-          <span className='text-sm font-semibold'>전남대학교</span>
-          <span className='text-xs text-gray-500'>전남대1팀</span>
-        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className='group flex cursor-pointer items-center gap-3 outline-none'>
+              <div className='relative'>
+                <Bell />
+                <span className='absolute right-0 top-0 block h-2 w-2 rounded-full bg-red-500' />
+              </div>
+              <div className='flex flex-col text-right'>
+                <span className='text-sm font-semibold'>전남대학교</span>
+                <span className='text-xs text-gray-500'>전남대1팀</span>
+              </div>
+              <ChevronDown className='h-4 w-4 text-gray-500 transition-transform group-data-[state=open]:rotate-180' />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align='end' sideOffset={8} className='w-40'>
+            <DropdownMenuItem
+              onSelect={(e) => {
+                e.preventDefault();
+                navigate(ROUTES.my);
+              }}
+            >
+              내 설정
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
         <Button
           variant='destructive'
           size='sm'

--- a/src/widgets/header/ui/HeaderLogin.tsx
+++ b/src/widgets/header/ui/HeaderLogin.tsx
@@ -2,6 +2,8 @@ import { Separator } from '@/shared/ui/shadcn/separator';
 import { SidebarTrigger } from '@/shared/ui/shadcn/sidebar';
 import { useLocation } from 'react-router-dom';
 import { getActiveItem } from '../model/getActiveItem';
+import { Bell } from 'lucide-react';
+import { Button } from '@/shared/ui/shadcn/button';
 
 export function HeaderLogin() {
   const location = useLocation();
@@ -13,6 +15,19 @@ export function HeaderLogin() {
       <SidebarTrigger />
       <Separator orientation='vertical' />
       <div className='text-sm font-medium'>{activeItem?.title}</div>
+      <div className='ml-auto flex items-center gap-4'>
+        <div className='relative'>
+          <Bell />
+          <span className='absolute right-0 top-0 block h-2 w-2 rounded-full bg-red-500' />
+        </div>
+        <div className='flex flex-col text-right'>
+          <span className='text-sm font-semibold'>전남대학교</span>
+          <span className='text-xs text-gray-500'>전남대1팀</span>
+        </div>
+        <Button variant='destructive' size='sm' className='rounded-full'>
+          로그아웃
+        </Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #55

## #️⃣ 작업 내용

- 헤더 우측에 **사용자 정보 드롭다운 메뉴** 추가  
  - 트리거: `Bell` 아이콘 + 이름/닉네임 + `ChevronDown` (lucide-react)  
  - 메뉴 항목: **내 설정(= 마이페이지)**, **로그아웃**  
  - 열림 상태 시 `ChevronDown` 회전(시각적 힌트)
- **shadcn/ui** 컴포넌트 적용  
  - `DropdownMenu`, `DropdownMenuTrigger`, `DropdownMenuContent`, `DropdownMenuItem`  
  - 로그아웃 버튼: `Button variant="destructive" size="sm"`
- **라우팅 연동**  
  - “내 설정” 선택 시 `navigate(ROUTES.my)` → 팀 라우트 기준 `/mypage` 매핑
- **로그아웃 연동**  
  - `useLogout()` 훅 사용: `mutate` 호출로 세션 종료 처리  
  - 진행 중 상태(`isPending`)에서 버튼 비활성화 + 라벨 “로그아웃 중…”
- **표시 조건**  
  - 로그인 상태에서만 우측 사용자 메뉴 노출 (스토어/훅 기준)
- **UI/레이아웃**  
  - 헤더 우측 정렬(`ml-auto`) 및 간격(`gap-4`) 정리  
  - 알림 뱃지(빨간 점) 표시

**주요 변경 파일**
- `src/widgets/header/ui/HeaderLogin.tsx`  
  (shadcn DropdownMenu/Lucide 아이콘/로그아웃 훅/라우팅 연동)

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (PR 본문에 요약 및 사용법 기재)
- [x] 코드 컨벤션에 따라 코드를 작성했나요? (FSD 경로, alias 사용, shadcn 컴포넌트 규칙)
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?  
  - lucide-react / shadcn/ui 사용 중 충돌 없음 확인  
  - `ROUTES.my`가 `/mypage`에 매핑되는지 라우트 테이블 확인 필요

## #️⃣ 리뷰 요구사항 (선택)

- **접근성**: 드롭다운 트리거 버튼의 키보드 포커스/ARIA 속성 보강이 필요한지 확인 부탁드립니다.  
- **상태관리**: 비로그인 상태에서 헤더 우측 사용자 메뉴가 숨김 처리되는지 확인 부탁드립니다.  
- **로딩 상태**: `useLogout()` 진행 중 버튼 비활성화/라벨 변경이 UI에 자연스럽게 반영되는지 체크 부탁드립니다.

<img width="1470" height="801" alt="image" src="https://github.com/user-attachments/assets/247ac1a6-8c4c-46cd-97a2-5123e66a49c1" />
