### PR TITLE
Feature/post edit delete

### DIFF
--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -1,0 +1,2 @@
+export * from './ui/CommentList';
+export * from './ui/CommentItem';

--- a/src/entities/comment/ui/CommentList.tsx
+++ b/src/entities/comment/ui/CommentList.tsx
@@ -79,5 +79,3 @@ export function CommentList({ postId, className }: CommentListProps) {
     </Card>
   );
 }
-
-export default CommentList;

--- a/src/entities/post/index.ts
+++ b/src/entities/post/index.ts
@@ -4,3 +4,4 @@ export * from './model/usePostByCategory';
 export * from './ui/PostCard.skeleton';
 export * from './ui/PostDetail';
 export * from './ui/PostMeta';
+export * from './model/usePostDetail';

--- a/src/entities/post/lib/postService.ts
+++ b/src/entities/post/lib/postService.ts
@@ -7,6 +7,7 @@ import type {
   PostStatsResponse,
   PostId,
   CategoryResponse,
+  UpdatePostRequest,
 } from '../model/post.type';
 import type { CreatePostFormValues } from '@/features/create-post/lib/post.scheme';
 
@@ -48,5 +49,15 @@ export const postService = {
   async likePost(postId: number) {
     const { data } = await axiosInstance.post(`/posts/${postId}/likes`);
     return data;
+  },
+
+  async updatePost(postId: PostId, body: UpdatePostRequest): Promise<PostDetailResponse> {
+    // 익명 여부는 수정 불가 (전달하지 않음)
+    const { data } = await axiosInstance.patch<PostDetailResponse>(`/posts/${postId}`, body);
+    return data;
+  },
+
+  async deletePost(postId: PostId): Promise<void> {
+    await axiosInstance.delete(`/posts/${postId}`);
   },
 };

--- a/src/entities/post/model/post.type.ts
+++ b/src/entities/post/model/post.type.ts
@@ -9,20 +9,6 @@ export type CategoryCode =
   | 'HOBBY'
   | 'MENTAL'
   | 'TROUBLE';
-
-export const CATEGORY_CODES = [
-  'ALL',
-  'FREE',
-  'STUDY',
-  'CAREER',
-  'RELATIONSHIP',
-  'SOCIAL',
-  'FAMILY',
-  'HOBBY',
-  'MENTAL',
-  'TROUBLE',
-] as const;
-
 export interface CategoryResponse {
   code: CategoryCode;
   displayName: string;

--- a/src/entities/post/model/post.type.ts
+++ b/src/entities/post/model/post.type.ts
@@ -66,3 +66,9 @@ export interface PostDetailResponse {
   createdAt: string; // 작성일 (ISO 8601)
   updatedAt: string; // 수정일 (ISO 8601)
 }
+
+export type UpdatePostRequest = {
+  title?: string;
+  content?: string;
+  postCategory?: CategoryCode; // 서버 스펙에 맞춰 key 이름 주의
+};

--- a/src/entities/post/model/post.type.ts
+++ b/src/entities/post/model/post.type.ts
@@ -10,6 +10,19 @@ export type CategoryCode =
   | 'MENTAL'
   | 'TROUBLE';
 
+export const CATEGORY_CODES = [
+  'ALL',
+  'FREE',
+  'STUDY',
+  'CAREER',
+  'RELATIONSHIP',
+  'SOCIAL',
+  'FAMILY',
+  'HOBBY',
+  'MENTAL',
+  'TROUBLE',
+] as const;
+
 export interface CategoryResponse {
   code: CategoryCode;
   displayName: string;
@@ -51,7 +64,7 @@ export type PostId = number;
 
 export interface PostDetailResponse {
   id: number;
-  postCategory: string; // 카테고리 코드 (예: "TROUBLE")
+  postCategory: CategoryCode; // 카테고리 코드 (예: "TROUBLE")
   postCategoryName: string; // 카테고리 한글 이름 (예: "고민상담")
   title: string;
   content: string;

--- a/src/entities/post/model/useDeletePost.ts
+++ b/src/entities/post/model/useDeletePost.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { postService } from '@/entities/post/lib/postService';
+import { postKeys } from '@/entities/post/model/queryKeys';
+import { ROUTES } from '@/shared/config';
+
+export const useDeletePost = (postId: number) => {
+  const qc = useQueryClient();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: () => postService.deletePost(postId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: postKeys.lists() });
+      navigate(ROUTES.landing);
+    },
+  });
+};

--- a/src/entities/post/ui/PostDetail.tsx
+++ b/src/entities/post/ui/PostDetail.tsx
@@ -15,7 +15,6 @@ type PostDetailProps = {
   onClickReport?: () => void;
   actionSlot?: React.ReactNode; // 공유 등
 };
-
 export function PostDetail({
   post,
   className,
@@ -24,12 +23,27 @@ export function PostDetail({
   actionSlot,
 }: PostDetailProps) {
   const initials = post.author?.slice(0, 2) ?? 'U';
+
   return (
     <Card className={cn('w-full', className)}>
-      <CardHeader>
-        <CardTitle className='text-2xl'>{post.title}</CardTitle>
+      <CardHeader className='relative'>
+        {/* 제목 + 버튼 그룹 */}
+        <div className='flex items-start justify-between'>
+          <CardTitle className='text-2xl'>{post.title}</CardTitle>
+
+          {/* 수정 / 삭제 버튼 */}
+          <div className='flex gap-2'>
+            <Button variant='outline' size='sm' onClick={() => console.log('수정 클릭')}>
+              수정
+            </Button>
+            <Button variant='destructive' size='sm' onClick={() => console.log('삭제 클릭')}>
+              삭제
+            </Button>
+          </div>
+        </div>
+
         <CardDescription>
-          <div className='flex items-center gap-3 text-sm'>
+          <div className='mt-2 flex items-center gap-3 text-sm'>
             <Avatar className='h-8 w-8'>
               {post.author ? <AvatarImage src={post.author} alt={`${post.author} avatar`} /> : null}
               <AvatarFallback>{initials}</AvatarFallback>
@@ -42,6 +56,7 @@ export function PostDetail({
           </div>
         </CardDescription>
       </CardHeader>
+
       <CardContent>
         <div className='prose max-w-none whitespace-pre-wrap leading-7'>{post.content}</div>
 
@@ -60,6 +75,7 @@ export function PostDetail({
               {post.viewCount}
             </span>
           </div>
+
           <div className='flex items-center gap-2'>
             <Button variant='outline' size='sm' onClick={() => onClickLike?.(post.id)}>
               {post.isLiked ? (

--- a/src/entities/post/ui/PostDetail.tsx
+++ b/src/entities/post/ui/PostDetail.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { Eye, Heart, MessageSquare, Flag } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
@@ -10,35 +8,46 @@ import type { PostDetailResponse } from '../model/post.type';
 
 type PostDetailProps = {
   post: PostDetailResponse;
+  isRevise: boolean;
+  setIsRevise: (value: boolean) => void;
   className?: string;
   onClickLike?: (postId: number) => void;
   onClickReport?: () => void;
   actionSlot?: React.ReactNode; // 공유 등
+  reviseActionSlot?: React.ReactNode;
 };
 export function PostDetail({
   post,
+  isRevise,
+  setIsRevise,
   className,
   onClickLike,
   onClickReport,
   actionSlot,
+  reviseActionSlot,
 }: PostDetailProps) {
   const initials = post.author?.slice(0, 2) ?? 'U';
-
   return (
     <Card className={cn('w-full', className)}>
       <CardHeader className='relative'>
         {/* 제목 + 버튼 그룹 */}
         <div className='flex items-start justify-between'>
-          <CardTitle className='text-2xl'>{post.title}</CardTitle>
+          <CardTitle className='text-2xl'>{isRevise ? '게시글 수정' : post.title}</CardTitle>
 
-          {/* 수정 / 삭제 버튼 */}
           <div className='flex gap-2'>
-            <Button variant='outline' size='sm' onClick={() => console.log('수정 클릭')}>
-              수정
-            </Button>
-            <Button variant='destructive' size='sm' onClick={() => console.log('삭제 클릭')}>
-              삭제
-            </Button>
+            {isRevise ? (
+              // 수정 모드: 외부에서 주입한 액션(완료/취소 버튼 등) 표시
+              <>{reviseActionSlot}</>
+            ) : (
+              <>
+                <Button variant='outline' size='sm' onClick={() => setIsRevise(true)}>
+                  수정
+                </Button>
+                <Button variant='destructive' size='sm'>
+                  삭제
+                </Button>
+              </>
+            )}
           </div>
         </div>
 
@@ -58,40 +67,44 @@ export function PostDetail({
       </CardHeader>
 
       <CardContent>
-        <div className='prose max-w-none whitespace-pre-wrap leading-7'>{post.content}</div>
+        {isRevise ? (
+          actionSlot
+        ) : (
+          <>
+            <div className='text-muted-foreground mt-6 flex items-center justify-between text-sm'>
+              <div className='flex items-center gap-4'>
+                <span className='inline-flex items-center gap-1'>
+                  <Heart className='h-4 w-4' />
+                  {post.likeCount}
+                </span>
+                <span className='inline-flex items-center gap-1'>
+                  <MessageSquare className='h-4 w-4' />
+                  {post.commentCount}
+                </span>
+                <span className='inline-flex items-center gap-1'>
+                  <Eye className='h-4 w-4' />
+                  {post.viewCount}
+                </span>
+              </div>
 
-        <div className='text-muted-foreground mt-6 flex items-center justify-between text-sm'>
-          <div className='flex items-center gap-4'>
-            <span className='inline-flex items-center gap-1'>
-              <Heart className='h-4 w-4' />
-              {post.likeCount}
-            </span>
-            <span className='inline-flex items-center gap-1'>
-              <MessageSquare className='h-4 w-4' />
-              {post.commentCount}
-            </span>
-            <span className='inline-flex items-center gap-1'>
-              <Eye className='h-4 w-4' />
-              {post.viewCount}
-            </span>
-          </div>
-
-          <div className='flex items-center gap-2'>
-            <Button variant='outline' size='sm' onClick={() => onClickLike?.(post.id)}>
-              {post.isLiked ? (
-                <Heart className='mr-1 h-4 w-4 fill-red-500 text-red-500' />
-              ) : (
-                <Heart className='mr-1 h-4 w-4' />
-              )}
-              좋아요
-            </Button>
-            <Button variant='ghost' size='sm' onClick={onClickReport}>
-              <Flag className='mr-1 h-4 w-4' />
-              신고
-            </Button>
-            {actionSlot}
-          </div>
-        </div>
+              <div className='flex items-center gap-2'>
+                <Button variant='outline' size='sm' onClick={() => onClickLike?.(post.id)}>
+                  {post.isLiked ? (
+                    <Heart className='mr-1 h-4 w-4 fill-red-500 text-red-500' />
+                  ) : (
+                    <Heart className='mr-1 h-4 w-4' />
+                  )}
+                  좋아요
+                </Button>
+                <Button variant='ghost' size='sm' onClick={onClickReport}>
+                  <Flag className='mr-1 h-4 w-4' />
+                  신고
+                </Button>
+                {actionSlot}
+              </div>
+            </div>
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/entities/post/ui/PostDetail.tsx
+++ b/src/entities/post/ui/PostDetail.tsx
@@ -13,6 +13,7 @@ type PostDetailProps = {
   className?: string;
   onClickLike?: (postId: number) => void;
   onClickReport?: () => void;
+  onClickDelete: () => void;
   actionSlot?: React.ReactNode; // 공유 등
   reviseActionSlot?: React.ReactNode;
 };
@@ -23,6 +24,7 @@ export function PostDetail({
   className,
   onClickLike,
   onClickReport,
+  onClickDelete,
   actionSlot,
   reviseActionSlot,
 }: PostDetailProps) {
@@ -43,7 +45,7 @@ export function PostDetail({
                 <Button variant='outline' size='sm' onClick={() => setIsRevise(true)}>
                   수정
                 </Button>
-                <Button variant='destructive' size='sm'>
+                <Button variant='destructive' size='sm' onClick={onClickDelete}>
                   삭제
                 </Button>
               </>

--- a/src/entities/post/ui/PostDetail.tsx
+++ b/src/entities/post/ui/PostDetail.tsx
@@ -71,6 +71,8 @@ export function PostDetail({
           actionSlot
         ) : (
           <>
+            <div className='prose max-w-none whitespace-pre-wrap leading-7'>{post.content}</div>
+
             <div className='text-muted-foreground mt-6 flex items-center justify-between text-sm'>
               <div className='flex items-center gap-4'>
                 <span className='inline-flex items-center gap-1'>

--- a/src/features/delete-post/index.ts
+++ b/src/features/delete-post/index.ts
@@ -1,0 +1,1 @@
+export * from './ui/ConfirmDeleteModal';

--- a/src/features/delete-post/ui/ConfirmDeleteModal.tsx
+++ b/src/features/delete-post/ui/ConfirmDeleteModal.tsx
@@ -1,0 +1,30 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/shared/ui/dialog';
+import { Button } from '@/shared/ui/button';
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isPending?: boolean;
+};
+
+export function ConfirmDeleteModal({ open, onOpenChange, onConfirm, isPending }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>게시글을 삭제할까요?</DialogTitle>
+        </DialogHeader>
+        <p>삭제 후 되돌릴 수 없습니다.</p>
+        <DialogFooter>
+          <Button variant='outline' onClick={() => onOpenChange(false)} disabled={isPending}>
+            취소
+          </Button>
+          <Button variant='destructive' onClick={onConfirm} disabled={isPending}>
+            {isPending ? '삭제 중…' : '삭제'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/edit-post/index.ts
+++ b/src/features/edit-post/index.ts
@@ -1,0 +1,3 @@
+export * from './ui/EditPostForm';
+export * from './model/useUpdatePost';
+export * from './model/postEdit.schema';

--- a/src/features/edit-post/model/postEdit.schema.ts
+++ b/src/features/edit-post/model/postEdit.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const postEditSchema = z.object({
+  title: z.string().min(1, '제목은 필수입니다.').max(100),
+  content: z.string().min(1, '내용은 필수입니다.'),
+  postCategory: z.any().optional(),
+});
+
+export type PostEditValues = z.infer<typeof postEditSchema>;

--- a/src/features/edit-post/model/postEdit.schema.ts
+++ b/src/features/edit-post/model/postEdit.schema.ts
@@ -1,9 +1,10 @@
+import { CATEGORY_CODES } from '@/entities/post';
 import { z } from 'zod';
 
 export const postEditSchema = z.object({
   title: z.string().min(1, '제목은 필수입니다.').max(100),
   content: z.string().min(1, '내용은 필수입니다.'),
-  postCategory: z.any().optional(),
+  postCategory: z.enum(CATEGORY_CODES).optional(),
 });
 
 export type PostEditValues = z.infer<typeof postEditSchema>;

--- a/src/features/edit-post/model/postEdit.schema.ts
+++ b/src/features/edit-post/model/postEdit.schema.ts
@@ -1,10 +1,8 @@
-import { CATEGORY_CODES } from '@/entities/post';
 import { z } from 'zod';
 
 export const postEditSchema = z.object({
   title: z.string().min(1, '제목은 필수입니다.').max(100),
   content: z.string().min(1, '내용은 필수입니다.'),
-  postCategory: z.enum(CATEGORY_CODES).optional(),
 });
 
 export type PostEditValues = z.infer<typeof postEditSchema>;

--- a/src/features/edit-post/model/useUpdatePost.ts
+++ b/src/features/edit-post/model/useUpdatePost.ts
@@ -2,13 +2,12 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postService } from '@/entities/post/lib/postService';
 import { postKeys } from '@/entities/post/model/queryKeys';
 import { commentKeys } from '@/entities/comment/model/queryKeys';
-import type { CategoryCode } from '@/entities/post';
+import type { UpdatePostRequest } from '@/entities/post';
 
 export const useUpdatePost = (postId: number) => {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (body: { title?: string; content?: string; postCategory?: CategoryCode }) =>
-      postService.updatePost(postId, body),
+    mutationFn: (body: UpdatePostRequest) => postService.updatePost(postId, body),
     onSuccess: () => {
       // 상세 & 목록/통계 등 관련 캐시 무효화
       qc.invalidateQueries({ queryKey: postKeys.detail(postId) });

--- a/src/features/edit-post/model/useUpdatePost.ts
+++ b/src/features/edit-post/model/useUpdatePost.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { postService } from '@/entities/post/lib/postService';
+import { postKeys } from '@/entities/post/model/queryKeys';
+import { commentKeys } from '@/entities/comment/model/queryKeys';
+import type { CategoryCode } from '@/entities/post';
+
+export const useUpdatePost = (postId: number) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { title?: string; content?: string; postCategory?: CategoryCode }) =>
+      postService.updatePost(postId, body),
+    onSuccess: () => {
+      // 상세 & 목록/통계 등 관련 캐시 무효화
+      qc.invalidateQueries({ queryKey: postKeys.detail(postId) });
+      qc.invalidateQueries({ queryKey: postKeys.lists() });
+      qc.invalidateQueries({ queryKey: commentKeys.listByPost(postId) });
+    },
+  });
+};

--- a/src/features/edit-post/ui/EditPostForm.tsx
+++ b/src/features/edit-post/ui/EditPostForm.tsx
@@ -1,11 +1,10 @@
-// src/features/edit-post/ui/EditPostForm.tsx
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/shared/ui/form';
 import { Input } from '@/shared/ui/input';
 import { Textarea } from '@/shared/ui/textarea';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
+
 import { postEditSchema, type PostEditValues } from '../model/postEdit.schema';
 
 type Props = {
@@ -52,33 +51,6 @@ export function EditPostForm({ defaultValues, onSubmit, id = 'postEditForm', dis
                   {...field}
                   disabled={disabled}
                 />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name='postCategory'
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>카테고리</FormLabel>
-              <FormControl>
-                <Select
-                  onValueChange={field.onChange}
-                  defaultValue={field.value}
-                  disabled={disabled}
-                >
-                  <SelectTrigger className='w-full'>
-                    <SelectValue placeholder='카테고리를 선택하세요' />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value='FREE'>자유</SelectItem>
-                    <SelectItem value='TROUBLE'>고민상담</SelectItem>
-                    <SelectItem value='NOTICE'>공지사항</SelectItem>
-                  </SelectContent>
-                </Select>
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/src/features/edit-post/ui/EditPostForm.tsx
+++ b/src/features/edit-post/ui/EditPostForm.tsx
@@ -1,0 +1,90 @@
+// src/features/edit-post/ui/EditPostForm.tsx
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/shared/ui/form';
+import { Input } from '@/shared/ui/input';
+import { Textarea } from '@/shared/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
+import { postEditSchema, type PostEditValues } from '../model/postEdit.schema';
+
+type Props = {
+  defaultValues: PostEditValues;
+  onSubmit: (values: PostEditValues) => void | Promise<void>;
+  id?: string; // 외부 submit 용 (ex: "postEditForm")
+  disabled?: boolean;
+};
+
+export function EditPostForm({ defaultValues, onSubmit, id = 'postEditForm', disabled }: Props) {
+  const form = useForm<PostEditValues>({
+    resolver: zodResolver(postEditSchema),
+    defaultValues,
+    mode: 'onChange',
+  });
+
+  return (
+    <Form {...form}>
+      <form id={id} className='space-y-4' onSubmit={form.handleSubmit(onSubmit)}>
+        <FormField
+          control={form.control}
+          name='title'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>제목</FormLabel>
+              <FormControl>
+                <Input placeholder='제목을 입력하세요' {...field} disabled={disabled} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name='content'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>내용</FormLabel>
+              <FormControl>
+                <Textarea
+                  className='min-h-[180px]'
+                  placeholder='내용을 입력하세요'
+                  {...field}
+                  disabled={disabled}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name='postCategory'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>카테고리</FormLabel>
+              <FormControl>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                  disabled={disabled}
+                >
+                  <SelectTrigger className='w-full'>
+                    <SelectValue placeholder='카테고리를 선택하세요' />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value='FREE'>자유</SelectItem>
+                    <SelectItem value='TROUBLE'>고민상담</SelectItem>
+                    <SelectItem value='NOTICE'>공지사항</SelectItem>
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </form>
+    </Form>
+  );
+}

--- a/src/pages/post-detail/ui/PostDetailPage.tsx
+++ b/src/pages/post-detail/ui/PostDetailPage.tsx
@@ -1,11 +1,12 @@
 import { SuspenseBoundary } from '@/shared/ui/boundary/SuspenseBoundary';
-import PostDetailContent from '@/widgets/PostDetailContent/ui/PostDetailContent';
+
 import PostDetailContentSkeleton from '@/widgets/PostDetailContent/ui/PostDetailContent.skeleton';
 
 import { useNavigate, useParams } from 'react-router-dom';
 import { FileText } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
 import { SectionHeader } from '@/shared/ui/section-header';
+import { PostDetailContent } from '@/widgets/PostDetailContent/ui/PostDetailContent';
 
 export function PostDetailPage() {
   const { id } = useParams();

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -51,7 +51,7 @@ export function PostDetailContent({ postId }: Props) {
               defaultValues={{
                 title: post.title,
                 content: post.content,
-                postCategory: post.postCategory ?? 'FREE',
+                postCategory: post.postCategory,
               }}
               onSubmit={handleSubmit}
             />

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -1,28 +1,70 @@
+import { useState } from 'react';
 import { usePostDetailQuery } from '@/entities/post/model/usePostDetail';
-import CommentList from '@/entities/comment/ui/CommentList';
 import { PostDetail } from '@/entities/post/ui/PostDetail';
-import { useToggleLike } from '@/features/like-post';
 import { AddCommentForm } from '@/features/add-comment/ui/AddCommentForm';
+import CommentList from '@/entities/comment/ui/CommentList';
+import { useToggleLike } from '@/features/like-post';
+import { EditPostForm, useUpdatePost, type PostEditValues } from '@/features/edit-post';
+import { Button } from '@/shared/ui/button';
 
-type Props = {
-  postId: number;
-};
+type Props = { postId: number };
 
 export function PostDetailContent({ postId }: Props) {
-  const { data } = usePostDetailQuery(postId);
-  const { mutate } = useToggleLike();
+  const { data: post } = usePostDetailQuery(postId);
+  const { mutate: toggleLike } = useToggleLike();
+  const [isRevise, setIsRevise] = useState(false);
+  const { mutate: updatePost, isPending } = useUpdatePost(postId);
+  const handleSubmit = (values: PostEditValues) => {
+    updatePost(values, {
+      onSuccess: () => {
+        setIsRevise(false);
+      },
+      // 필요 시 에러 처리도 여기서
+      // onError: (e) => toast.error(e.message),
+    });
+  };
 
   return (
     <div className='space-y-6'>
-      <PostDetail post={data} onClickLike={(postId: number) => mutate(postId)} />
+      <PostDetail
+        post={post}
+        isRevise={isRevise}
+        setIsRevise={setIsRevise}
+        onClickLike={(id) => toggleLike(id)}
+        // 수정 모드일 때 상단 버튼
+        reviseActionSlot={
+          <>
+            <Button type='submit' form='postEditForm' disabled={isPending}>
+              {isPending ? '저장 중…' : '완료'}
+            </Button>
+            <Button variant='outline' onClick={() => setIsRevise(false)} disabled={isPending}>
+              취소
+            </Button>
+          </>
+        }
+        // 수정 모드일 때 본문 컨텐츠(= 폼) 주입
+        actionSlot={
+          isRevise ?? (
+            <EditPostForm
+              id='postEditForm'
+              disabled={isPending}
+              defaultValues={{
+                title: post.title,
+                content: post.content,
+                postCategory: post.postCategory ?? 'FREE',
+              }}
+              onSubmit={handleSubmit}
+            />
+          )
+        }
+      />
 
-      {/* 댓글 추가 박스 */}
-      <AddCommentForm postId={postId} />
-
-      {/* 댓글 리스트 */}
-      <CommentList postId={postId} />
+      {!isRevise && (
+        <>
+          <AddCommentForm postId={postId} />
+          <CommentList postId={postId} />
+        </>
+      )}
     </div>
   );
 }
-
-export default PostDetailContent;

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -44,7 +44,7 @@ export function PostDetailContent({ postId }: Props) {
         }
         // 수정 모드일 때 본문 컨텐츠(= 폼) 주입
         actionSlot={
-          isRevise ?? (
+          isRevise && (
             <EditPostForm
               id='postEditForm'
               disabled={isPending}

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-import { usePostDetailQuery } from '@/entities/post';
-import { PostDetail } from '@/entities/post/';
+import { usePostDetailQuery, PostDetail } from '@/entities/post';
 import { AddCommentForm } from '@/features/add-comment/';
 import { CommentList } from '@/entities/comment';
 import { useToggleLike } from '@/features/like-post';
@@ -43,7 +42,7 @@ export function PostDetailContent({ postId }: Props) {
         post={post}
         isRevise={isRevise}
         setIsRevise={setIsRevise}
-        onClickLike={(id) => toggleLike(id)}
+        onClickLike={toggleLike}
         onClickDelete={() => setShowDeleteModal(true)} // ← 삭제 버튼 트리거 연결
         reviseActionSlot={
           <>

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -7,6 +7,8 @@ import { useToggleLike } from '@/features/like-post';
 import { EditPostForm, useUpdatePost, type PostEditValues } from '@/features/edit-post';
 import { Button } from '@/shared/ui/button';
 
+import { LandingPageFilterTabs } from '@/features/landing';
+
 type Props = { postId: number };
 
 export function PostDetailContent({ postId }: Props) {
@@ -14,14 +16,20 @@ export function PostDetailContent({ postId }: Props) {
   const { mutate: toggleLike } = useToggleLike();
   const [isRevise, setIsRevise] = useState(false);
   const { mutate: updatePost, isPending } = useUpdatePost(postId);
+
+  const [category, setCategory] = useState(post.postCategory);
+
   const handleSubmit = (values: PostEditValues) => {
-    updatePost(values, {
-      onSuccess: () => {
-        setIsRevise(false);
+    updatePost(
+      { ...values, postCategory: category },
+      {
+        onSuccess: () => {
+          setIsRevise(false);
+        },
+        // 필요 시 에러 처리도 여기서
+        // onError: (e) => toast.error(e.message),
       },
-      // 필요 시 에러 처리도 여기서
-      // onError: (e) => toast.error(e.message),
-    });
+    );
   };
 
   return (
@@ -45,16 +53,18 @@ export function PostDetailContent({ postId }: Props) {
         // 수정 모드일 때 본문 컨텐츠(= 폼) 주입
         actionSlot={
           isRevise && (
-            <EditPostForm
-              id='postEditForm'
-              disabled={isPending}
-              defaultValues={{
-                title: post.title,
-                content: post.content,
-                postCategory: post.postCategory,
-              }}
-              onSubmit={handleSubmit}
-            />
+            <>
+              <LandingPageFilterTabs category={category} setCategory={setCategory} />
+              <EditPostForm
+                id='postEditForm'
+                disabled={isPending}
+                defaultValues={{
+                  title: post.title,
+                  content: post.content,
+                }}
+                onSubmit={handleSubmit}
+              />
+            </>
           )
         }
       />

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -7,14 +7,17 @@ import { useToggleLike } from '@/features/like-post';
 import { EditPostForm, useUpdatePost, type PostEditValues } from '@/features/edit-post';
 import { Button } from '@/shared/ui/button';
 import { LandingPageFilterTabs } from '@/features/landing';
+import { ConfirmDeleteModal } from '@/features/delete-post';
+import { useDeletePost } from '@/entities/post/model/useDeletePost';
 
 export function PostDetailContent(postId: number) {
   const { data: post } = usePostDetailQuery(postId);
   const { mutate: toggleLike } = useToggleLike();
   const [isRevise, setIsRevise] = useState(false);
   const { mutate: updatePost, isPending } = useUpdatePost(postId);
-
   const [category, setCategory] = useState(post.postCategory);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const { mutate: deletePost, isPending: isDeleting } = useDeletePost(postId);
 
   const handleSubmit = (values: PostEditValues) => {
     updatePost(
@@ -29,6 +32,11 @@ export function PostDetailContent(postId: number) {
     );
   };
 
+  const handleDelete = () => {
+    deletePost();
+    setShowDeleteModal(false);
+  };
+
   return (
     <div className='space-y-6'>
       <PostDetail
@@ -36,7 +44,7 @@ export function PostDetailContent(postId: number) {
         isRevise={isRevise}
         setIsRevise={setIsRevise}
         onClickLike={(id) => toggleLike(id)}
-        // 수정 모드일 때 상단 버튼
+        onClickDelete={() => setShowDeleteModal(true)} // ← 삭제 버튼 트리거 연결
         reviseActionSlot={
           <>
             <Button type='submit' form='postEditForm' disabled={isPending}>
@@ -72,6 +80,12 @@ export function PostDetailContent(postId: number) {
           <CommentList postId={postId} />
         </>
       )}
+      <ConfirmDeleteModal
+        open={showDeleteModal}
+        onOpenChange={setShowDeleteModal}
+        onConfirm={handleDelete}
+        isPending={isDeleting}
+      />
     </div>
   );
 }

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -9,8 +9,8 @@ import { Button } from '@/shared/ui/button';
 import { LandingPageFilterTabs } from '@/features/landing';
 import { ConfirmDeleteModal } from '@/features/delete-post';
 import { useDeletePost } from '@/entities/post/model/useDeletePost';
-
-export function PostDetailContent(postId: number) {
+type Props = { postId: number };
+export function PostDetailContent({ postId }: Props) {
   const { data: post } = usePostDetailQuery(postId);
   const { mutate: toggleLike } = useToggleLike();
   const [isRevise, setIsRevise] = useState(false);

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -1,17 +1,14 @@
 import { useState } from 'react';
-import { usePostDetailQuery } from '@/entities/post/model/usePostDetail';
-import { PostDetail } from '@/entities/post/ui/PostDetail';
-import { AddCommentForm } from '@/features/add-comment/ui/AddCommentForm';
-import CommentList from '@/entities/comment/ui/CommentList';
+import { usePostDetailQuery } from '@/entities/post';
+import { PostDetail } from '@/entities/post/';
+import { AddCommentForm } from '@/features/add-comment/';
+import { CommentList } from '@/entities/comment';
 import { useToggleLike } from '@/features/like-post';
 import { EditPostForm, useUpdatePost, type PostEditValues } from '@/features/edit-post';
 import { Button } from '@/shared/ui/button';
-
 import { LandingPageFilterTabs } from '@/features/landing';
 
-type Props = { postId: number };
-
-export function PostDetailContent({ postId }: Props) {
+export function PostDetailContent(postId: number) {
   const { data: post } = usePostDetailQuery(postId);
   const { mutate: toggleLike } = useToggleLike();
   const [isRevise, setIsRevise] = useState(false);


### PR DESCRIPTION
# [FEATURE] 게시글 수정 및 삭제 기능 추가

## #️⃣ 연관된 이슈
close #98

---

## #️⃣ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

- 게시글 상세 페이지에서 **수정(Edit) / 삭제(Delete)** 기능 추가  
- 수정 시 기존 게시글 데이터를 **폼에 프리필(pre-fill)**하여 편집 가능  
- 삭제 시 **확인 모달(ConfirmDeleteModal)**을 통해 재확인 후 서버 요청  
- 성공 시 **라우팅 처리** 및 **TanStack Query 캐시 무효화**로 최신 상태 반영  
- FSD 기준으로 **feature 레벨**로 분리(컴포넌트/훅/라우팅 정리)

**구현 요약**
- 상세 페이지에 `Edit` / `Delete` 버튼 노출  
- `react-hook-form` + `zod`로 유효성 검증  
- `useUpdatePost`, `useDeletePost` 훅 구현  
- 성공 시 `queryClient.invalidateQueries(postKeys.detail(id))` 및 목록 캐시 무효화

---

## #️⃣ 변경 사항 체크리스트
- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-place post editing with validated title (1–100 chars) and non-empty content, Save/Cancel flow, and backend update.
  * Delete posts from the detail view with confirmation modal, loading state, and return to listing on success.
  * Edit form integrates category handling; comments and add-comment are hidden while editing.

* **UX**
  * Edit mode replaces post content with an editor while preserving metrics/actions and contextual revision controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->