### PR TITLE
[7회차 코드리뷰] Release/2025 10 27

### DIFF
--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -1,0 +1,2 @@
+export * from './ui/CommentList';
+export * from './ui/CommentItem';

--- a/src/entities/comment/ui/CommentList.tsx
+++ b/src/entities/comment/ui/CommentList.tsx
@@ -79,5 +79,3 @@ export function CommentList({ postId, className }: CommentListProps) {
     </Card>
   );
 }
-
-export default CommentList;

--- a/src/entities/post/index.ts
+++ b/src/entities/post/index.ts
@@ -4,3 +4,4 @@ export * from './model/usePostByCategory';
 export * from './ui/PostCard.skeleton';
 export * from './ui/PostDetail';
 export * from './ui/PostMeta';
+export * from './model/usePostDetail';

--- a/src/entities/post/lib/postService.ts
+++ b/src/entities/post/lib/postService.ts
@@ -7,6 +7,7 @@ import type {
   PostStatsResponse,
   PostId,
   CategoryResponse,
+  UpdatePostRequest,
 } from '../model/post.type';
 import type { CreatePostFormValues } from '@/features/create-post/lib/post.scheme';
 
@@ -48,5 +49,15 @@ export const postService = {
   async likePost(postId: number) {
     const { data } = await axiosInstance.post(`/posts/${postId}/likes`);
     return data;
+  },
+
+  async updatePost(postId: PostId, body: UpdatePostRequest): Promise<PostDetailResponse> {
+    // 익명 여부는 수정 불가 (전달하지 않음)
+    const { data } = await axiosInstance.patch<PostDetailResponse>(`/posts/${postId}`, body);
+    return data;
+  },
+
+  async deletePost(postId: PostId): Promise<void> {
+    await axiosInstance.delete(`/posts/${postId}`);
   },
 };

--- a/src/entities/post/model/post.type.ts
+++ b/src/entities/post/model/post.type.ts
@@ -9,20 +9,6 @@ export type CategoryCode =
   | 'HOBBY'
   | 'MENTAL'
   | 'TROUBLE';
-
-export const CATEGORY_CODES = [
-  'ALL',
-  'FREE',
-  'STUDY',
-  'CAREER',
-  'RELATIONSHIP',
-  'SOCIAL',
-  'FAMILY',
-  'HOBBY',
-  'MENTAL',
-  'TROUBLE',
-] as const;
-
 export interface CategoryResponse {
   code: CategoryCode;
   displayName: string;

--- a/src/entities/post/model/post.type.ts
+++ b/src/entities/post/model/post.type.ts
@@ -66,3 +66,9 @@ export interface PostDetailResponse {
   createdAt: string; // 작성일 (ISO 8601)
   updatedAt: string; // 수정일 (ISO 8601)
 }
+
+export type UpdatePostRequest = {
+  title?: string;
+  content?: string;
+  postCategory?: CategoryCode; // 서버 스펙에 맞춰 key 이름 주의
+};

--- a/src/entities/post/model/post.type.ts
+++ b/src/entities/post/model/post.type.ts
@@ -10,6 +10,19 @@ export type CategoryCode =
   | 'MENTAL'
   | 'TROUBLE';
 
+export const CATEGORY_CODES = [
+  'ALL',
+  'FREE',
+  'STUDY',
+  'CAREER',
+  'RELATIONSHIP',
+  'SOCIAL',
+  'FAMILY',
+  'HOBBY',
+  'MENTAL',
+  'TROUBLE',
+] as const;
+
 export interface CategoryResponse {
   code: CategoryCode;
   displayName: string;
@@ -51,7 +64,7 @@ export type PostId = number;
 
 export interface PostDetailResponse {
   id: number;
-  postCategory: string; // 카테고리 코드 (예: "TROUBLE")
+  postCategory: CategoryCode; // 카테고리 코드 (예: "TROUBLE")
   postCategoryName: string; // 카테고리 한글 이름 (예: "고민상담")
   title: string;
   content: string;

--- a/src/entities/post/model/useDeletePost.ts
+++ b/src/entities/post/model/useDeletePost.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { postService } from '@/entities/post/lib/postService';
+import { postKeys } from '@/entities/post/model/queryKeys';
+import { ROUTES } from '@/shared/config';
+
+export const useDeletePost = (postId: number) => {
+  const qc = useQueryClient();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: () => postService.deletePost(postId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: postKeys.lists() });
+      navigate(ROUTES.landing);
+    },
+  });
+};

--- a/src/entities/post/ui/PostDetail.tsx
+++ b/src/entities/post/ui/PostDetail.tsx
@@ -15,7 +15,6 @@ type PostDetailProps = {
   onClickReport?: () => void;
   actionSlot?: React.ReactNode; // 공유 등
 };
-
 export function PostDetail({
   post,
   className,
@@ -24,12 +23,27 @@ export function PostDetail({
   actionSlot,
 }: PostDetailProps) {
   const initials = post.author?.slice(0, 2) ?? 'U';
+
   return (
     <Card className={cn('w-full', className)}>
-      <CardHeader>
-        <CardTitle className='text-2xl'>{post.title}</CardTitle>
+      <CardHeader className='relative'>
+        {/* 제목 + 버튼 그룹 */}
+        <div className='flex items-start justify-between'>
+          <CardTitle className='text-2xl'>{post.title}</CardTitle>
+
+          {/* 수정 / 삭제 버튼 */}
+          <div className='flex gap-2'>
+            <Button variant='outline' size='sm' onClick={() => console.log('수정 클릭')}>
+              수정
+            </Button>
+            <Button variant='destructive' size='sm' onClick={() => console.log('삭제 클릭')}>
+              삭제
+            </Button>
+          </div>
+        </div>
+
         <CardDescription>
-          <div className='flex items-center gap-3 text-sm'>
+          <div className='mt-2 flex items-center gap-3 text-sm'>
             <Avatar className='h-8 w-8'>
               {post.author ? <AvatarImage src={post.author} alt={`${post.author} avatar`} /> : null}
               <AvatarFallback>{initials}</AvatarFallback>
@@ -42,6 +56,7 @@ export function PostDetail({
           </div>
         </CardDescription>
       </CardHeader>
+
       <CardContent>
         <div className='prose max-w-none whitespace-pre-wrap leading-7'>{post.content}</div>
 
@@ -60,6 +75,7 @@ export function PostDetail({
               {post.viewCount}
             </span>
           </div>
+
           <div className='flex items-center gap-2'>
             <Button variant='outline' size='sm' onClick={() => onClickLike?.(post.id)}>
               {post.isLiked ? (

--- a/src/entities/post/ui/PostDetail.tsx
+++ b/src/entities/post/ui/PostDetail.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { Eye, Heart, MessageSquare, Flag } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
@@ -10,35 +8,46 @@ import type { PostDetailResponse } from '../model/post.type';
 
 type PostDetailProps = {
   post: PostDetailResponse;
+  isRevise: boolean;
+  setIsRevise: (value: boolean) => void;
   className?: string;
   onClickLike?: (postId: number) => void;
   onClickReport?: () => void;
   actionSlot?: React.ReactNode; // 공유 등
+  reviseActionSlot?: React.ReactNode;
 };
 export function PostDetail({
   post,
+  isRevise,
+  setIsRevise,
   className,
   onClickLike,
   onClickReport,
   actionSlot,
+  reviseActionSlot,
 }: PostDetailProps) {
   const initials = post.author?.slice(0, 2) ?? 'U';
-
   return (
     <Card className={cn('w-full', className)}>
       <CardHeader className='relative'>
         {/* 제목 + 버튼 그룹 */}
         <div className='flex items-start justify-between'>
-          <CardTitle className='text-2xl'>{post.title}</CardTitle>
+          <CardTitle className='text-2xl'>{isRevise ? '게시글 수정' : post.title}</CardTitle>
 
-          {/* 수정 / 삭제 버튼 */}
           <div className='flex gap-2'>
-            <Button variant='outline' size='sm' onClick={() => console.log('수정 클릭')}>
-              수정
-            </Button>
-            <Button variant='destructive' size='sm' onClick={() => console.log('삭제 클릭')}>
-              삭제
-            </Button>
+            {isRevise ? (
+              // 수정 모드: 외부에서 주입한 액션(완료/취소 버튼 등) 표시
+              <>{reviseActionSlot}</>
+            ) : (
+              <>
+                <Button variant='outline' size='sm' onClick={() => setIsRevise(true)}>
+                  수정
+                </Button>
+                <Button variant='destructive' size='sm'>
+                  삭제
+                </Button>
+              </>
+            )}
           </div>
         </div>
 
@@ -58,40 +67,44 @@ export function PostDetail({
       </CardHeader>
 
       <CardContent>
-        <div className='prose max-w-none whitespace-pre-wrap leading-7'>{post.content}</div>
+        {isRevise ? (
+          actionSlot
+        ) : (
+          <>
+            <div className='text-muted-foreground mt-6 flex items-center justify-between text-sm'>
+              <div className='flex items-center gap-4'>
+                <span className='inline-flex items-center gap-1'>
+                  <Heart className='h-4 w-4' />
+                  {post.likeCount}
+                </span>
+                <span className='inline-flex items-center gap-1'>
+                  <MessageSquare className='h-4 w-4' />
+                  {post.commentCount}
+                </span>
+                <span className='inline-flex items-center gap-1'>
+                  <Eye className='h-4 w-4' />
+                  {post.viewCount}
+                </span>
+              </div>
 
-        <div className='text-muted-foreground mt-6 flex items-center justify-between text-sm'>
-          <div className='flex items-center gap-4'>
-            <span className='inline-flex items-center gap-1'>
-              <Heart className='h-4 w-4' />
-              {post.likeCount}
-            </span>
-            <span className='inline-flex items-center gap-1'>
-              <MessageSquare className='h-4 w-4' />
-              {post.commentCount}
-            </span>
-            <span className='inline-flex items-center gap-1'>
-              <Eye className='h-4 w-4' />
-              {post.viewCount}
-            </span>
-          </div>
-
-          <div className='flex items-center gap-2'>
-            <Button variant='outline' size='sm' onClick={() => onClickLike?.(post.id)}>
-              {post.isLiked ? (
-                <Heart className='mr-1 h-4 w-4 fill-red-500 text-red-500' />
-              ) : (
-                <Heart className='mr-1 h-4 w-4' />
-              )}
-              좋아요
-            </Button>
-            <Button variant='ghost' size='sm' onClick={onClickReport}>
-              <Flag className='mr-1 h-4 w-4' />
-              신고
-            </Button>
-            {actionSlot}
-          </div>
-        </div>
+              <div className='flex items-center gap-2'>
+                <Button variant='outline' size='sm' onClick={() => onClickLike?.(post.id)}>
+                  {post.isLiked ? (
+                    <Heart className='mr-1 h-4 w-4 fill-red-500 text-red-500' />
+                  ) : (
+                    <Heart className='mr-1 h-4 w-4' />
+                  )}
+                  좋아요
+                </Button>
+                <Button variant='ghost' size='sm' onClick={onClickReport}>
+                  <Flag className='mr-1 h-4 w-4' />
+                  신고
+                </Button>
+                {actionSlot}
+              </div>
+            </div>
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/entities/post/ui/PostDetail.tsx
+++ b/src/entities/post/ui/PostDetail.tsx
@@ -12,6 +12,7 @@ type PostDetailProps = {
   setIsRevise: (value: boolean) => void;
   className?: string;
   onClickLike?: (postId: number) => void;
+  onClickUnlike?: (postId: number) => void;
   onClickReport?: () => void;
   onClickDelete: () => void;
   actionSlot?: React.ReactNode; // 공유 등
@@ -23,6 +24,7 @@ export function PostDetail({
   setIsRevise,
   className,
   onClickLike,
+  onClickUnlike,
   onClickReport,
   onClickDelete,
   actionSlot,
@@ -92,7 +94,11 @@ export function PostDetail({
               </div>
 
               <div className='flex items-center gap-2'>
-                <Button variant='outline' size='sm' onClick={() => onClickLike?.(post.id)}>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  onClick={() => (post.isLiked ? onClickUnlike?.(post.id) : onClickLike?.(post.id))}
+                >
                   {post.isLiked ? (
                     <Heart className='mr-1 h-4 w-4 fill-red-500 text-red-500' />
                   ) : (

--- a/src/entities/post/ui/PostDetail.tsx
+++ b/src/entities/post/ui/PostDetail.tsx
@@ -13,6 +13,7 @@ type PostDetailProps = {
   className?: string;
   onClickLike?: (postId: number) => void;
   onClickReport?: () => void;
+  onClickDelete: () => void;
   actionSlot?: React.ReactNode; // 공유 등
   reviseActionSlot?: React.ReactNode;
 };
@@ -23,6 +24,7 @@ export function PostDetail({
   className,
   onClickLike,
   onClickReport,
+  onClickDelete,
   actionSlot,
   reviseActionSlot,
 }: PostDetailProps) {
@@ -43,7 +45,7 @@ export function PostDetail({
                 <Button variant='outline' size='sm' onClick={() => setIsRevise(true)}>
                   수정
                 </Button>
-                <Button variant='destructive' size='sm'>
+                <Button variant='destructive' size='sm' onClick={onClickDelete}>
                   삭제
                 </Button>
               </>

--- a/src/entities/post/ui/PostDetail.tsx
+++ b/src/entities/post/ui/PostDetail.tsx
@@ -14,6 +14,7 @@ type PostDetailProps = {
   onClickLike?: (postId: number) => void;
   onClickUnlike?: (postId: number) => void;
   likeDisabled?: boolean;
+  unlikeDisabled?: boolean;
   onClickReport?: () => void;
   onClickDelete: () => void;
   actionSlot?: React.ReactNode; // 공유 등
@@ -27,6 +28,7 @@ export function PostDetail({
   onClickLike,
   onClickUnlike,
   likeDisabled,
+  unlikeDisabled,
   onClickReport,
   onClickDelete,
   actionSlot,
@@ -46,20 +48,10 @@ export function PostDetail({
               <>{reviseActionSlot}</>
             ) : (
               <>
-                <Button
-                  variant='outline'
-                  size='sm'
-                  disabled={likeDisabled}
-                  onClick={() => setIsRevise(true)}
-                >
+                <Button variant='outline' size='sm' onClick={() => setIsRevise(true)}>
                   수정
                 </Button>
-                <Button
-                  variant='destructive'
-                  size='sm'
-                  disabled={likeDisabled}
-                  onClick={onClickDelete}
-                >
+                <Button variant='destructive' size='sm' onClick={onClickDelete}>
                   삭제
                 </Button>
               </>
@@ -109,6 +101,7 @@ export function PostDetail({
                 <Button
                   variant='outline'
                   size='sm'
+                  disabled={post.isLiked ? unlikeDisabled : likeDisabled}
                   onClick={() => (post.isLiked ? onClickUnlike?.(post.id) : onClickLike?.(post.id))}
                 >
                   {post.isLiked ? (

--- a/src/entities/post/ui/PostDetail.tsx
+++ b/src/entities/post/ui/PostDetail.tsx
@@ -13,6 +13,7 @@ type PostDetailProps = {
   className?: string;
   onClickLike?: (postId: number) => void;
   onClickUnlike?: (postId: number) => void;
+  likeDisabled?: boolean;
   onClickReport?: () => void;
   onClickDelete: () => void;
   actionSlot?: React.ReactNode; // 공유 등
@@ -25,6 +26,7 @@ export function PostDetail({
   className,
   onClickLike,
   onClickUnlike,
+  likeDisabled,
   onClickReport,
   onClickDelete,
   actionSlot,
@@ -44,10 +46,20 @@ export function PostDetail({
               <>{reviseActionSlot}</>
             ) : (
               <>
-                <Button variant='outline' size='sm' onClick={() => setIsRevise(true)}>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  disabled={likeDisabled}
+                  onClick={() => setIsRevise(true)}
+                >
                   수정
                 </Button>
-                <Button variant='destructive' size='sm' onClick={onClickDelete}>
+                <Button
+                  variant='destructive'
+                  size='sm'
+                  disabled={likeDisabled}
+                  onClick={onClickDelete}
+                >
                   삭제
                 </Button>
               </>

--- a/src/entities/post/ui/PostDetail.tsx
+++ b/src/entities/post/ui/PostDetail.tsx
@@ -71,6 +71,8 @@ export function PostDetail({
           actionSlot
         ) : (
           <>
+            <div className='prose max-w-none whitespace-pre-wrap leading-7'>{post.content}</div>
+
             <div className='text-muted-foreground mt-6 flex items-center justify-between text-sm'>
               <div className='flex items-center gap-4'>
                 <span className='inline-flex items-center gap-1'>

--- a/src/features/delete-post/index.ts
+++ b/src/features/delete-post/index.ts
@@ -1,0 +1,1 @@
+export * from './ui/ConfirmDeleteModal';

--- a/src/features/delete-post/ui/ConfirmDeleteModal.tsx
+++ b/src/features/delete-post/ui/ConfirmDeleteModal.tsx
@@ -1,0 +1,30 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/shared/ui/dialog';
+import { Button } from '@/shared/ui/button';
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isPending?: boolean;
+};
+
+export function ConfirmDeleteModal({ open, onOpenChange, onConfirm, isPending }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>게시글을 삭제할까요?</DialogTitle>
+        </DialogHeader>
+        <p>삭제 후 되돌릴 수 없습니다.</p>
+        <DialogFooter>
+          <Button variant='outline' onClick={() => onOpenChange(false)} disabled={isPending}>
+            취소
+          </Button>
+          <Button variant='destructive' onClick={onConfirm} disabled={isPending}>
+            {isPending ? '삭제 중…' : '삭제'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/edit-post/index.ts
+++ b/src/features/edit-post/index.ts
@@ -1,0 +1,3 @@
+export * from './ui/EditPostForm';
+export * from './model/useUpdatePost';
+export * from './model/postEdit.schema';

--- a/src/features/edit-post/model/postEdit.schema.ts
+++ b/src/features/edit-post/model/postEdit.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const postEditSchema = z.object({
+  title: z.string().min(1, '제목은 필수입니다.').max(100),
+  content: z.string().min(1, '내용은 필수입니다.'),
+  postCategory: z.any().optional(),
+});
+
+export type PostEditValues = z.infer<typeof postEditSchema>;

--- a/src/features/edit-post/model/postEdit.schema.ts
+++ b/src/features/edit-post/model/postEdit.schema.ts
@@ -1,9 +1,10 @@
+import { CATEGORY_CODES } from '@/entities/post';
 import { z } from 'zod';
 
 export const postEditSchema = z.object({
   title: z.string().min(1, '제목은 필수입니다.').max(100),
   content: z.string().min(1, '내용은 필수입니다.'),
-  postCategory: z.any().optional(),
+  postCategory: z.enum(CATEGORY_CODES).optional(),
 });
 
 export type PostEditValues = z.infer<typeof postEditSchema>;

--- a/src/features/edit-post/model/postEdit.schema.ts
+++ b/src/features/edit-post/model/postEdit.schema.ts
@@ -1,10 +1,8 @@
-import { CATEGORY_CODES } from '@/entities/post';
 import { z } from 'zod';
 
 export const postEditSchema = z.object({
   title: z.string().min(1, '제목은 필수입니다.').max(100),
   content: z.string().min(1, '내용은 필수입니다.'),
-  postCategory: z.enum(CATEGORY_CODES).optional(),
 });
 
 export type PostEditValues = z.infer<typeof postEditSchema>;

--- a/src/features/edit-post/model/useUpdatePost.ts
+++ b/src/features/edit-post/model/useUpdatePost.ts
@@ -2,13 +2,12 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postService } from '@/entities/post/lib/postService';
 import { postKeys } from '@/entities/post/model/queryKeys';
 import { commentKeys } from '@/entities/comment/model/queryKeys';
-import type { CategoryCode } from '@/entities/post';
+import type { UpdatePostRequest } from '@/entities/post';
 
 export const useUpdatePost = (postId: number) => {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (body: { title?: string; content?: string; postCategory?: CategoryCode }) =>
-      postService.updatePost(postId, body),
+    mutationFn: (body: UpdatePostRequest) => postService.updatePost(postId, body),
     onSuccess: () => {
       // 상세 & 목록/통계 등 관련 캐시 무효화
       qc.invalidateQueries({ queryKey: postKeys.detail(postId) });

--- a/src/features/edit-post/model/useUpdatePost.ts
+++ b/src/features/edit-post/model/useUpdatePost.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { postService } from '@/entities/post/lib/postService';
+import { postKeys } from '@/entities/post/model/queryKeys';
+import { commentKeys } from '@/entities/comment/model/queryKeys';
+import type { CategoryCode } from '@/entities/post';
+
+export const useUpdatePost = (postId: number) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { title?: string; content?: string; postCategory?: CategoryCode }) =>
+      postService.updatePost(postId, body),
+    onSuccess: () => {
+      // 상세 & 목록/통계 등 관련 캐시 무효화
+      qc.invalidateQueries({ queryKey: postKeys.detail(postId) });
+      qc.invalidateQueries({ queryKey: postKeys.lists() });
+      qc.invalidateQueries({ queryKey: commentKeys.listByPost(postId) });
+    },
+  });
+};

--- a/src/features/edit-post/ui/EditPostForm.tsx
+++ b/src/features/edit-post/ui/EditPostForm.tsx
@@ -1,11 +1,10 @@
-// src/features/edit-post/ui/EditPostForm.tsx
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/shared/ui/form';
 import { Input } from '@/shared/ui/input';
 import { Textarea } from '@/shared/ui/textarea';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
+
 import { postEditSchema, type PostEditValues } from '../model/postEdit.schema';
 
 type Props = {
@@ -52,33 +51,6 @@ export function EditPostForm({ defaultValues, onSubmit, id = 'postEditForm', dis
                   {...field}
                   disabled={disabled}
                 />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name='postCategory'
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>카테고리</FormLabel>
-              <FormControl>
-                <Select
-                  onValueChange={field.onChange}
-                  defaultValue={field.value}
-                  disabled={disabled}
-                >
-                  <SelectTrigger className='w-full'>
-                    <SelectValue placeholder='카테고리를 선택하세요' />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value='FREE'>자유</SelectItem>
-                    <SelectItem value='TROUBLE'>고민상담</SelectItem>
-                    <SelectItem value='NOTICE'>공지사항</SelectItem>
-                  </SelectContent>
-                </Select>
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/src/features/edit-post/ui/EditPostForm.tsx
+++ b/src/features/edit-post/ui/EditPostForm.tsx
@@ -1,0 +1,90 @@
+// src/features/edit-post/ui/EditPostForm.tsx
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/shared/ui/form';
+import { Input } from '@/shared/ui/input';
+import { Textarea } from '@/shared/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
+import { postEditSchema, type PostEditValues } from '../model/postEdit.schema';
+
+type Props = {
+  defaultValues: PostEditValues;
+  onSubmit: (values: PostEditValues) => void | Promise<void>;
+  id?: string; // 외부 submit 용 (ex: "postEditForm")
+  disabled?: boolean;
+};
+
+export function EditPostForm({ defaultValues, onSubmit, id = 'postEditForm', disabled }: Props) {
+  const form = useForm<PostEditValues>({
+    resolver: zodResolver(postEditSchema),
+    defaultValues,
+    mode: 'onChange',
+  });
+
+  return (
+    <Form {...form}>
+      <form id={id} className='space-y-4' onSubmit={form.handleSubmit(onSubmit)}>
+        <FormField
+          control={form.control}
+          name='title'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>제목</FormLabel>
+              <FormControl>
+                <Input placeholder='제목을 입력하세요' {...field} disabled={disabled} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name='content'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>내용</FormLabel>
+              <FormControl>
+                <Textarea
+                  className='min-h-[180px]'
+                  placeholder='내용을 입력하세요'
+                  {...field}
+                  disabled={disabled}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name='postCategory'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>카테고리</FormLabel>
+              <FormControl>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                  disabled={disabled}
+                >
+                  <SelectTrigger className='w-full'>
+                    <SelectValue placeholder='카테고리를 선택하세요' />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value='FREE'>자유</SelectItem>
+                    <SelectItem value='TROUBLE'>고민상담</SelectItem>
+                    <SelectItem value='NOTICE'>공지사항</SelectItem>
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </form>
+    </Form>
+  );
+}

--- a/src/features/like-post/api/like-post.api.ts
+++ b/src/features/like-post/api/like-post.api.ts
@@ -1,6 +1,0 @@
-import { axiosInstance } from '@/shared/api/base/axiosInstance';
-
-export async function likePost(postId: number) {
-  const { data } = await axiosInstance.post(`/api/posts/${postId}/likes`);
-  return data;
-}

--- a/src/features/like-post/api/likePostService.ts
+++ b/src/features/like-post/api/likePostService.ts
@@ -1,0 +1,13 @@
+import { axiosInstance } from '@/shared/api/base/axiosInstance';
+
+export const likePostService = {
+  async likePost(postId: number) {
+    const { data } = await axiosInstance.post(`/posts/${postId}/likes`);
+    return data;
+  },
+
+  async unlikePost(postId: number) {
+    const { data } = await axiosInstance.delete(`/posts/${postId}/likes`);
+    return data;
+  },
+};

--- a/src/features/like-post/model/useToggleUnlike.ts
+++ b/src/features/like-post/model/useToggleUnlike.ts
@@ -4,16 +4,16 @@ import { likePostService } from '../api/likePostService';
 import { postKeys } from '@/entities/post/model/queryKeys';
 
 /**
- * Like(좋아요)용 커스텀 훅
- * - 상세 캐시에 낙관적 업데이트( likeCount + 1, isLiked=true )
+ * Unlike(좋아요 취소)용 커스텀 훅
+ * - 상세 캐시에 낙관적 업데이트( likeCount - 1, isLiked=false )
  * - 실패 시 롤백
  * - 완료 후 리스트/상세 무효화로 최종 동기화
  */
-export function useToggleLike() {
+export function useToggleUnlike() {
   const qc = useQueryClient();
 
   return useMutation({
-    mutationFn: (postId: number) => likePostService.likePost(postId),
+    mutationFn: (postId: number) => likePostService.unlikePost(postId),
 
     // 1) 서버 호출 전에 낙관적 업데이트
     onMutate: async (postId: number) => {
@@ -28,8 +28,8 @@ export function useToggleLike() {
       if (prevDetail) {
         const nextDetail: PostDetailResponse = {
           ...prevDetail,
-          isLiked: true,
-          likeCount: (prevDetail.likeCount ?? 0) + 1,
+          isLiked: false,
+          likeCount: Math.max(0, (prevDetail.likeCount ?? 0) - 1),
         };
         qc.setQueryData(postKeys.detail(postId), nextDetail);
       }

--- a/src/pages/post-detail/ui/PostDetailPage.tsx
+++ b/src/pages/post-detail/ui/PostDetailPage.tsx
@@ -1,11 +1,12 @@
 import { SuspenseBoundary } from '@/shared/ui/boundary/SuspenseBoundary';
-import PostDetailContent from '@/widgets/PostDetailContent/ui/PostDetailContent';
+
 import PostDetailContentSkeleton from '@/widgets/PostDetailContent/ui/PostDetailContent.skeleton';
 
 import { useNavigate, useParams } from 'react-router-dom';
 import { FileText } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
 import { SectionHeader } from '@/shared/ui/section-header';
+import { PostDetailContent } from '@/widgets/PostDetailContent/ui/PostDetailContent';
 
 export function PostDetailPage() {
   const { id } = useParams();

--- a/src/shared/api/mocks/handlers/postDetail.ts
+++ b/src/shared/api/mocks/handlers/postDetail.ts
@@ -14,7 +14,7 @@ export const postDetailHandlers = [
       handle: '@yozjov',
       isAnonymous: false,
       isDeleted: false,
-      isLiked: true,
+      isLiked: false,
       viewCount: 0,
       likeCount: 0,
       commentCount: 1,

--- a/src/shared/api/mocks/handlers/postDetail.ts
+++ b/src/shared/api/mocks/handlers/postDetail.ts
@@ -14,7 +14,7 @@ export const postDetailHandlers = [
       handle: '@yozjov',
       isAnonymous: false,
       isDeleted: false,
-      isLiked: false,
+      isLiked: true,
       viewCount: 0,
       likeCount: 0,
       commentCount: 1,

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -51,7 +51,7 @@ export function PostDetailContent({ postId }: Props) {
               defaultValues={{
                 title: post.title,
                 content: post.content,
-                postCategory: post.postCategory ?? 'FREE',
+                postCategory: post.postCategory,
               }}
               onSubmit={handleSubmit}
             />

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -1,28 +1,70 @@
+import { useState } from 'react';
 import { usePostDetailQuery } from '@/entities/post/model/usePostDetail';
-import CommentList from '@/entities/comment/ui/CommentList';
 import { PostDetail } from '@/entities/post/ui/PostDetail';
-import { useToggleLike } from '@/features/like-post';
 import { AddCommentForm } from '@/features/add-comment/ui/AddCommentForm';
+import CommentList from '@/entities/comment/ui/CommentList';
+import { useToggleLike } from '@/features/like-post';
+import { EditPostForm, useUpdatePost, type PostEditValues } from '@/features/edit-post';
+import { Button } from '@/shared/ui/button';
 
-type Props = {
-  postId: number;
-};
+type Props = { postId: number };
 
 export function PostDetailContent({ postId }: Props) {
-  const { data } = usePostDetailQuery(postId);
-  const { mutate } = useToggleLike();
+  const { data: post } = usePostDetailQuery(postId);
+  const { mutate: toggleLike } = useToggleLike();
+  const [isRevise, setIsRevise] = useState(false);
+  const { mutate: updatePost, isPending } = useUpdatePost(postId);
+  const handleSubmit = (values: PostEditValues) => {
+    updatePost(values, {
+      onSuccess: () => {
+        setIsRevise(false);
+      },
+      // 필요 시 에러 처리도 여기서
+      // onError: (e) => toast.error(e.message),
+    });
+  };
 
   return (
     <div className='space-y-6'>
-      <PostDetail post={data} onClickLike={(postId: number) => mutate(postId)} />
+      <PostDetail
+        post={post}
+        isRevise={isRevise}
+        setIsRevise={setIsRevise}
+        onClickLike={(id) => toggleLike(id)}
+        // 수정 모드일 때 상단 버튼
+        reviseActionSlot={
+          <>
+            <Button type='submit' form='postEditForm' disabled={isPending}>
+              {isPending ? '저장 중…' : '완료'}
+            </Button>
+            <Button variant='outline' onClick={() => setIsRevise(false)} disabled={isPending}>
+              취소
+            </Button>
+          </>
+        }
+        // 수정 모드일 때 본문 컨텐츠(= 폼) 주입
+        actionSlot={
+          isRevise ?? (
+            <EditPostForm
+              id='postEditForm'
+              disabled={isPending}
+              defaultValues={{
+                title: post.title,
+                content: post.content,
+                postCategory: post.postCategory ?? 'FREE',
+              }}
+              onSubmit={handleSubmit}
+            />
+          )
+        }
+      />
 
-      {/* 댓글 추가 박스 */}
-      <AddCommentForm postId={postId} />
-
-      {/* 댓글 리스트 */}
-      <CommentList postId={postId} />
+      {!isRevise && (
+        <>
+          <AddCommentForm postId={postId} />
+          <CommentList postId={postId} />
+        </>
+      )}
     </div>
   );
 }
-
-export default PostDetailContent;

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -44,7 +44,7 @@ export function PostDetailContent({ postId }: Props) {
         }
         // 수정 모드일 때 본문 컨텐츠(= 폼) 주입
         actionSlot={
-          isRevise ?? (
+          isRevise && (
             <EditPostForm
               id='postEditForm'
               disabled={isPending}

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-import { usePostDetailQuery } from '@/entities/post';
-import { PostDetail } from '@/entities/post/';
+import { usePostDetailQuery, PostDetail } from '@/entities/post';
 import { AddCommentForm } from '@/features/add-comment/';
 import { CommentList } from '@/entities/comment';
 import { useToggleLike } from '@/features/like-post';
@@ -43,7 +42,7 @@ export function PostDetailContent({ postId }: Props) {
         post={post}
         isRevise={isRevise}
         setIsRevise={setIsRevise}
-        onClickLike={(id) => toggleLike(id)}
+        onClickLike={toggleLike}
         onClickDelete={() => setShowDeleteModal(true)} // ← 삭제 버튼 트리거 연결
         reviseActionSlot={
           <>

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -7,6 +7,8 @@ import { useToggleLike } from '@/features/like-post';
 import { EditPostForm, useUpdatePost, type PostEditValues } from '@/features/edit-post';
 import { Button } from '@/shared/ui/button';
 
+import { LandingPageFilterTabs } from '@/features/landing';
+
 type Props = { postId: number };
 
 export function PostDetailContent({ postId }: Props) {
@@ -14,14 +16,20 @@ export function PostDetailContent({ postId }: Props) {
   const { mutate: toggleLike } = useToggleLike();
   const [isRevise, setIsRevise] = useState(false);
   const { mutate: updatePost, isPending } = useUpdatePost(postId);
+
+  const [category, setCategory] = useState(post.postCategory);
+
   const handleSubmit = (values: PostEditValues) => {
-    updatePost(values, {
-      onSuccess: () => {
-        setIsRevise(false);
+    updatePost(
+      { ...values, postCategory: category },
+      {
+        onSuccess: () => {
+          setIsRevise(false);
+        },
+        // 필요 시 에러 처리도 여기서
+        // onError: (e) => toast.error(e.message),
       },
-      // 필요 시 에러 처리도 여기서
-      // onError: (e) => toast.error(e.message),
-    });
+    );
   };
 
   return (
@@ -45,16 +53,18 @@ export function PostDetailContent({ postId }: Props) {
         // 수정 모드일 때 본문 컨텐츠(= 폼) 주입
         actionSlot={
           isRevise && (
-            <EditPostForm
-              id='postEditForm'
-              disabled={isPending}
-              defaultValues={{
-                title: post.title,
-                content: post.content,
-                postCategory: post.postCategory,
-              }}
-              onSubmit={handleSubmit}
-            />
+            <>
+              <LandingPageFilterTabs category={category} setCategory={setCategory} />
+              <EditPostForm
+                id='postEditForm'
+                disabled={isPending}
+                defaultValues={{
+                  title: post.title,
+                  content: post.content,
+                }}
+                onSubmit={handleSubmit}
+              />
+            </>
           )
         }
       />

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -9,18 +9,18 @@ import { LandingPageFilterTabs } from '@/features/landing';
 import { ConfirmDeleteModal } from '@/features/delete-post';
 import { useDeletePost } from '@/entities/post/model/useDeletePost';
 import { useToggleUnlike } from '@/features/like-post/model/useToggleUnlike';
-import { useIsMutating } from '@tanstack/react-query';
+
 type Props = { postId: number };
+
 export function PostDetailContent({ postId }: Props) {
   const { data: post } = usePostDetailQuery(postId);
-  const { mutate: toggleLike } = useToggleLike();
-  const { mutate: toggleUnlike } = useToggleUnlike();
+  const { mutate: toggleLike, isPending: likeBusy } = useToggleLike();
+  const { mutate: toggleUnlike, isPending: unlikeBusy } = useToggleUnlike();
   const [isRevise, setIsRevise] = useState(false);
   const { mutate: updatePost, isPending } = useUpdatePost(postId);
   const [category, setCategory] = useState(post.postCategory);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const { mutate: deletePost, isPending: isDeleting } = useDeletePost(postId);
-  const likeBusy = useIsMutating({ mutationKey: ['post-like'] }) > 0;
 
   const handleSubmit = (values: PostEditValues) => {
     updatePost(
@@ -49,6 +49,7 @@ export function PostDetailContent({ postId }: Props) {
         onClickLike={toggleLike}
         onClickUnlike={toggleUnlike}
         likeDisabled={likeBusy}
+        unlikeDisabled={unlikeBusy}
         onClickDelete={() => setShowDeleteModal(true)} // ← 삭제 버튼 트리거 연결
         reviseActionSlot={
           <>

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -7,14 +7,17 @@ import { useToggleLike } from '@/features/like-post';
 import { EditPostForm, useUpdatePost, type PostEditValues } from '@/features/edit-post';
 import { Button } from '@/shared/ui/button';
 import { LandingPageFilterTabs } from '@/features/landing';
+import { ConfirmDeleteModal } from '@/features/delete-post';
+import { useDeletePost } from '@/entities/post/model/useDeletePost';
 
 export function PostDetailContent(postId: number) {
   const { data: post } = usePostDetailQuery(postId);
   const { mutate: toggleLike } = useToggleLike();
   const [isRevise, setIsRevise] = useState(false);
   const { mutate: updatePost, isPending } = useUpdatePost(postId);
-
   const [category, setCategory] = useState(post.postCategory);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const { mutate: deletePost, isPending: isDeleting } = useDeletePost(postId);
 
   const handleSubmit = (values: PostEditValues) => {
     updatePost(
@@ -29,6 +32,11 @@ export function PostDetailContent(postId: number) {
     );
   };
 
+  const handleDelete = () => {
+    deletePost();
+    setShowDeleteModal(false);
+  };
+
   return (
     <div className='space-y-6'>
       <PostDetail
@@ -36,7 +44,7 @@ export function PostDetailContent(postId: number) {
         isRevise={isRevise}
         setIsRevise={setIsRevise}
         onClickLike={(id) => toggleLike(id)}
-        // 수정 모드일 때 상단 버튼
+        onClickDelete={() => setShowDeleteModal(true)} // ← 삭제 버튼 트리거 연결
         reviseActionSlot={
           <>
             <Button type='submit' form='postEditForm' disabled={isPending}>
@@ -72,6 +80,12 @@ export function PostDetailContent(postId: number) {
           <CommentList postId={postId} />
         </>
       )}
+      <ConfirmDeleteModal
+        open={showDeleteModal}
+        onOpenChange={setShowDeleteModal}
+        onConfirm={handleDelete}
+        isPending={isDeleting}
+      />
     </div>
   );
 }

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -9,6 +9,7 @@ import { LandingPageFilterTabs } from '@/features/landing';
 import { ConfirmDeleteModal } from '@/features/delete-post';
 import { useDeletePost } from '@/entities/post/model/useDeletePost';
 import { useToggleUnlike } from '@/features/like-post/model/useToggleUnlike';
+import { useIsMutating } from '@tanstack/react-query';
 type Props = { postId: number };
 export function PostDetailContent({ postId }: Props) {
   const { data: post } = usePostDetailQuery(postId);
@@ -19,6 +20,7 @@ export function PostDetailContent({ postId }: Props) {
   const [category, setCategory] = useState(post.postCategory);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const { mutate: deletePost, isPending: isDeleting } = useDeletePost(postId);
+  const likeBusy = useIsMutating({ mutationKey: ['post-like'] }) > 0;
 
   const handleSubmit = (values: PostEditValues) => {
     updatePost(
@@ -46,6 +48,7 @@ export function PostDetailContent({ postId }: Props) {
         setIsRevise={setIsRevise}
         onClickLike={toggleLike}
         onClickUnlike={toggleUnlike}
+        likeDisabled={likeBusy}
         onClickDelete={() => setShowDeleteModal(true)} // ← 삭제 버튼 트리거 연결
         reviseActionSlot={
           <>

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -8,10 +8,12 @@ import { Button } from '@/shared/ui/button';
 import { LandingPageFilterTabs } from '@/features/landing';
 import { ConfirmDeleteModal } from '@/features/delete-post';
 import { useDeletePost } from '@/entities/post/model/useDeletePost';
+import { useToggleUnlike } from '@/features/like-post/model/useToggleUnlike';
 type Props = { postId: number };
 export function PostDetailContent({ postId }: Props) {
   const { data: post } = usePostDetailQuery(postId);
   const { mutate: toggleLike } = useToggleLike();
+  const { mutate: toggleUnlike } = useToggleUnlike();
   const [isRevise, setIsRevise] = useState(false);
   const { mutate: updatePost, isPending } = useUpdatePost(postId);
   const [category, setCategory] = useState(post.postCategory);
@@ -43,6 +45,7 @@ export function PostDetailContent({ postId }: Props) {
         isRevise={isRevise}
         setIsRevise={setIsRevise}
         onClickLike={toggleLike}
+        onClickUnlike={toggleUnlike}
         onClickDelete={() => setShowDeleteModal(true)} // ← 삭제 버튼 트리거 연결
         reviseActionSlot={
           <>

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -9,8 +9,8 @@ import { Button } from '@/shared/ui/button';
 import { LandingPageFilterTabs } from '@/features/landing';
 import { ConfirmDeleteModal } from '@/features/delete-post';
 import { useDeletePost } from '@/entities/post/model/useDeletePost';
-
-export function PostDetailContent(postId: number) {
+type Props = { postId: number };
+export function PostDetailContent({ postId }: Props) {
   const { data: post } = usePostDetailQuery(postId);
   const { mutate: toggleLike } = useToggleLike();
   const [isRevise, setIsRevise] = useState(false);

--- a/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
+++ b/src/widgets/PostDetailContent/ui/PostDetailContent.tsx
@@ -1,17 +1,14 @@
 import { useState } from 'react';
-import { usePostDetailQuery } from '@/entities/post/model/usePostDetail';
-import { PostDetail } from '@/entities/post/ui/PostDetail';
-import { AddCommentForm } from '@/features/add-comment/ui/AddCommentForm';
-import CommentList from '@/entities/comment/ui/CommentList';
+import { usePostDetailQuery } from '@/entities/post';
+import { PostDetail } from '@/entities/post/';
+import { AddCommentForm } from '@/features/add-comment/';
+import { CommentList } from '@/entities/comment';
 import { useToggleLike } from '@/features/like-post';
 import { EditPostForm, useUpdatePost, type PostEditValues } from '@/features/edit-post';
 import { Button } from '@/shared/ui/button';
-
 import { LandingPageFilterTabs } from '@/features/landing';
 
-type Props = { postId: number };
-
-export function PostDetailContent({ postId }: Props) {
+export function PostDetailContent(postId: number) {
   const { data: post } = usePostDetailQuery(postId);
   const { mutate: toggleLike } = useToggleLike();
   const [isRevise, setIsRevise] = useState(false);


### PR DESCRIPTION
## #️⃣ 작업 내용

이번 PR에서는 게시글 상세 화면 및 관련 기능 전반에 걸쳐 **수정/삭제/좋아요 취소** 등 주요 기능 개선과 리팩터링을 진행했습니다.  

### 주요 변경 사항

- **UI 개선**
  - 포스터 디테일 화면에 **수정/삭제 버튼 추가** (`style`)

- **게시글 수정 기능**
  - 게시글 **수정 기능을 feature 레이어로 분리**
  - `PostDetail` 컴포넌트 구조 리팩터링
  - 수정 제출 시 **카테고리 탭 선택값으로 postCategory 전송**

- **게시글 삭제 기능**
  - **삭제 기능 구현** (확인 모달 + `useDeletePost` 훅)
  - 상세 화면과 연동 완료

- **카테고리 및 타입 정리**
  - `postCategory` 스키마: `z.any` → `z.enum(CATEGORY_CODES)`로 정리
  - `useUpdatePost` 요청 타입 **일원화**
  - `postId` 타입 불일치 문제 해결

- **댓글 및 코드 정리**
  - `CommentList` 네임드 익스포트 및 경로 정정
  - 불필요한 코드 정리 및 일원화

- **좋아요 기능 개선**
  - 좋아요 **취소 기능**에 낙관적 업데이트 적용
  - 중복 요청 방지를 위해 `busy 상태` 추가
  - `PostDetail`에 `likeDisabled / unlikeDisabled` prop 추가  
    → 버튼 비활성화 처리로 안정성 강화